### PR TITLE
fix: update compile and target sdks to 34 (android 14)

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/mozilla/social/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/mozilla/social/KotlinAndroid.kt
@@ -49,5 +49,5 @@ private fun Project.configureKotlin() {
     }
 }
 
-const val COMPILE_SDK = 33
+const val COMPILE_SDK = 34
 const val MIN_SDK = 27


### PR DESCRIPTION
Note: this actually updates both `compileSdk` and `targetSdk` due to how `targetSdk` is setup.

I think it's fine to be optimistic and do the update. I did a quick check and the app appears to keep working without any issues.

If anyone notices any issues, feel try to try to revert (just) `targetSdk` to 33 to see if it fixes things. As far as I'm concerned it's totally fine to keep it at 33 for now.

This unblocks #101.