### PR TITLE
block and mute

### DIFF
--- a/core/data/src/main/java/org/mozilla/social/core/data/RepositoryModule.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/RepositoryModule.kt
@@ -13,7 +13,7 @@ import org.mozilla.social.core.network.networkModule
 fun repositoryModule(isDebug: Boolean) = module {
     single { AuthTokenObserver(get(), get()) }
     single { StatusRepository(get(), get(), get()) }
-    single { AccountRepository(get()) }
+    single { AccountRepository(get(), get()) }
     single { TimelineRepository(get()) }
     single { AuthRepository(get()) }
     single { MediaRepository(get()) }

--- a/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
@@ -2,12 +2,14 @@ package org.mozilla.social.core.data.repository
 
 import kotlinx.coroutines.coroutineScope
 import org.mozilla.social.core.data.repository.model.status.toExternalModel
+import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.network.AccountApi
 import org.mozilla.social.model.Account
 import org.mozilla.social.model.Status
 
 class AccountRepository internal constructor(
-    private val accountApi: AccountApi
+    private val accountApi: AccountApi,
+    private val socialDatabase: SocialDatabase,
 ) {
 
     suspend fun getUserAccount(): Account {
@@ -50,5 +52,29 @@ class AccountRepository internal constructor(
 
     suspend fun unfollowAccount(accountId: String) {
         accountApi.unfollowAccount(accountId)
+    }
+
+    /**
+     * remove posts from any timelines before blocking
+     */
+    suspend fun blockAccount(accountId: String) {
+        socialDatabase.homeTimelineDao().remotePostsFromAccount(accountId)
+        accountApi.blockAccount(accountId)
+    }
+
+    suspend fun unblockAccount(accountId: String) {
+        accountApi.unblockAccount(accountId)
+    }
+
+    /**
+     * remove posts from any timelines before muting
+     */
+    suspend fun muteAccount(accountId: String) {
+        socialDatabase.homeTimelineDao().remotePostsFromAccount(accountId)
+        accountApi.muteAccount(accountId)
+    }
+
+    suspend fun unmuteAccount(accountId: String) {
+        accountApi.unmuteAccount(accountId)
     }
 }

--- a/core/database/src/main/java/org/mozilla/social/core/database/dao/HomeTimelineStatusDao.kt
+++ b/core/database/src/main/java/org/mozilla/social/core/database/dao/HomeTimelineStatusDao.kt
@@ -8,10 +8,19 @@ import org.mozilla.social.core.database.model.statusCollections.HomeTimelineStat
 
 @Dao
 interface HomeTimelineStatusDao : BaseDao<HomeTimelineStatus> {
-    @Query("SELECT * FROM homeTimeline " +
-            "ORDER BY createdAt DESC")
+    @Query(
+        "SELECT * FROM homeTimeline " +
+        "ORDER BY createdAt DESC"
+    )
     fun homeTimelinePagingSource(): PagingSource<Int, HomeTimelineStatusWrapper>
 
     @Query("DELETE FROM homeTimeline")
     fun deleteHomeTimeline()
+
+    @Query(
+        "DELETE FROM homeTimeline " +
+        "WHERE accountId = :accountId " +
+        "OR boostedStatusAccountId = :accountId"
+    )
+    suspend fun remotePostsFromAccount(accountId: String)
 }

--- a/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
+++ b/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
@@ -2,6 +2,8 @@ package org.mozilla.social.core.network
 
 import org.mozilla.social.core.network.model.NetworkAccount
 import org.mozilla.social.core.network.model.NetworkStatus
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -44,5 +46,30 @@ interface AccountApi {
     @POST("/api/v1/accounts/{accountId}/unfollow")
     suspend fun unfollowAccount(
         @Path("accountId") accountId: String
+    )
+
+    @POST("/api/v1/accounts/{accountId}/block")
+    suspend fun blockAccount(
+        @Path("accountId") accountId: String,
+    )
+
+    @POST("/api/v1/accounts/{accountId}/unblock")
+    suspend fun unblockAccount(
+        @Path("accountId") accountId: String,
+    )
+
+    /**
+     * @param duration how long to mute for in seconds.  0 is indefinite
+     */
+    @FormUrlEncoded
+    @POST("/api/v1/accounts/{accountId}/mute")
+    suspend fun muteAccount(
+        @Path("accountId") accountId: String,
+        @Field("duration") duration: Int = 0,
+    )
+
+    @POST("/api/v1/accounts/{accountId}/unmute")
+    suspend fun unmuteAccount(
+        @Path("accountId") accountId: String,
     )
 }

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
@@ -160,11 +160,6 @@ private fun MetaData(
                 }
             ) {
                 DropDownItem(
-                    text = "Follow ${post.username}",
-                    expanded = overflowMenuExpanded,
-                    onClick = { postCardInteractions.onOverflowFollowClicked(post.accountId) }
-                )
-                DropDownItem(
                     text = "Mute ${post.username}",
                     expanded = overflowMenuExpanded,
                     onClick = { postCardInteractions.onOverflowMuteClicked(post.accountId) }

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardDelegate.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardDelegate.kt
@@ -5,11 +5,13 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import org.mozilla.social.common.logging.Log
+import org.mozilla.social.core.data.repository.AccountRepository
 import org.mozilla.social.core.data.repository.StatusRepository
 
 class PostCardDelegate(
     private val coroutineScope: CoroutineScope,
     private val statusRepository: StatusRepository,
+    private val accountRepository: AccountRepository,
     private val log: Log,
     private val onReplyClicked: (String) -> Unit,
     private val onPostClicked: (String) -> Unit,
@@ -77,16 +79,26 @@ class PostCardDelegate(
         onPostClicked(statusId)
     }
 
-    override fun onOverflowFollowClicked(accountId: String) {
-        super.onOverflowFollowClicked(accountId)
-    }
-
     override fun onOverflowMuteClicked(accountId: String) {
-        super.onOverflowMuteClicked(accountId)
+        coroutineScope.launch {
+            try {
+                accountRepository.muteAccount(accountId)
+            } catch (e: Exception) {
+                log.e(e)
+                _errorToastMessage.emit("Error muting account")
+            }
+        }
     }
 
     override fun onOverflowBlockClicked(accountId: String) {
-        super.onOverflowBlockClicked(accountId)
+        coroutineScope.launch {
+            try {
+                accountRepository.blockAccount(accountId)
+            } catch (e: Exception) {
+                log.e(e)
+                _errorToastMessage.emit("Error blocking account")
+            }
+        }
     }
 
     override fun onOverflowReportClicked(accountId: String) {

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardInteractions.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardInteractions.kt
@@ -7,7 +7,6 @@ interface PostCardInteractions : PollInteractions {
     fun onBoostClicked(statusId: String, isBoosting: Boolean) = Unit
     fun onFavoriteClicked(statusId: String, isFavoriting: Boolean) = Unit
     fun onPostCardClicked(statusId: String) = Unit
-    fun onOverflowFollowClicked(accountId: String) = Unit
     fun onOverflowMuteClicked(accountId: String) = Unit
     fun onOverflowBlockClicked(accountId: String) = Unit
     fun onOverflowReportClicked(accountId: String) = Unit

--- a/feature/feed/src/main/java/org/mozilla/social/feed/FeedModule.kt
+++ b/feature/feed/src/main/java/org/mozilla/social/feed/FeedModule.kt
@@ -12,6 +12,7 @@ val feedModule = module {
         get(),
         get(),
         get(),
+        get(),
         parametersHolder[0],
         parametersHolder[1],
     ) }

--- a/feature/feed/src/main/java/org/mozilla/social/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/org/mozilla/social/feed/FeedViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.mozilla.social.common.logging.Log
+import org.mozilla.social.core.data.repository.AccountRepository
 import org.mozilla.social.core.data.repository.RecommendationRepository
 import org.mozilla.social.core.data.repository.StatusRepository
 import org.mozilla.social.core.data.repository.model.status.toExternalModel
@@ -33,6 +34,7 @@ class FeedViewModel(
     userPreferencesDatastore: UserPreferencesDatastore,
     statusRepository: StatusRepository,
     recommendationRepository: RecommendationRepository,
+    accountRepository: AccountRepository,
     private val socialDatabase: SocialDatabase,
     log: Log,
     onPostClicked: (String) -> Unit,
@@ -73,6 +75,7 @@ class FeedViewModel(
     val postCardDelegate = PostCardDelegate(
         coroutineScope = viewModelScope,
         statusRepository = statusRepository,
+        accountRepository = accountRepository,
         log = log,
         onReplyClicked = onReplyClicked,
         onPostClicked = onPostClicked,

--- a/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadModule.kt
+++ b/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadModule.kt
@@ -9,6 +9,7 @@ val threadModule = module {
         get(),
         get(),
         get(),
+        get(),
         parametersHolder[0],
         parametersHolder[1],
         parametersHolder[2],

--- a/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import org.mozilla.social.common.logging.Log
+import org.mozilla.social.core.data.repository.AccountRepository
 import org.mozilla.social.core.data.repository.StatusRepository
 import org.mozilla.social.core.datastore.UserPreferencesDatastore
 import org.mozilla.social.core.domain.GetThreadUseCase
@@ -17,6 +18,7 @@ import org.mozilla.social.core.ui.postcard.toPostCardUiState
 
 class ThreadViewModel(
     statusRepository: StatusRepository,
+    accountRepository: AccountRepository,
     log: Log,
     userPreferencesDatastore: UserPreferencesDatastore,
     getThreadUseCase: GetThreadUseCase,
@@ -41,6 +43,7 @@ class ThreadViewModel(
     val postCardDelegate = PostCardDelegate(
         coroutineScope = viewModelScope,
         statusRepository = statusRepository,
+        accountRepository = accountRepository,
         log = log,
         onPostClicked = onPostClicked,
         onReplyClicked = onReplyClicked,


### PR DESCRIPTION
Adding functionality to the block and mute buttons in the status card overflow menu.

Removing the follow button in the status card overflow menu.  I want to keep follow just in the account page for now because the account object returned by mastodon doesn't include the following state, so extra network calls would be required.  We could possibly add a follow option in the status card in the future, but I don't think it's necessary at the moment.