### PR TITLE
disabling dark theme

### DIFF
--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/theme/Theme.kt
@@ -215,7 +215,8 @@ fun MozillaSocialTheme(
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
 
-        darkTheme -> DarkColorScheme
+        //TODO enabled dark theme when it looks good
+//        darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
     val view = LocalView.current


### PR DESCRIPTION
Disabling dark theme for now because it looks really bad.  We can re-enable after we work on the design system.