### PR TITLE
build(gha): add gradle setup step to cache gradle and dependencies

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,6 +17,8 @@ jobs:
         distribution: 'temurin'
         # Using 'temurin' speeds up the job, because this distribution is cached by the runner.
         # See: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Hosted-Tool-Cache
+    - name: Set up Gradle
+      uses: gradle/gradle-build-action@v2.8.0
     - name: Set up Homebrew
       run: .github/workflows/setup-homebrew.sh
     - name: Set up Ruby


### PR DESCRIPTION
Gradle Build Action adds some common setup for builds that use Gradle, but most notably for us at this moment, it sets up caching. By default the cache is updated only from builds on the main branch and other builds only read from it. So adding it to the daily build enables updating the cache and should speed up the PR builds. It caches Gradle distribution and all the dependencies.

See: https://github.com/marketplace/actions/gradle-build-action