### PR TITLE
build(gha): cancel in-progress daily releases if a new one starts

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ "main" ]
 
+# Cancel in-progress/pending daily release workflows if a new one starts.
+# When we merge PRs one after another quickly, we only need one release with the latest code.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When I merged a couple of my PRs today I noticed that github doesn't automatically cancel older in-progress runs of the same workflow. I don't think we need separate releases for every merge, it's better to skip them and release the latest code more quickly. I think that's how we setup bitrise for pocket.

We probably want the same thing for PR checks (no need to run checks for an older commit if you just pushed a new one to the branch), but this is new syntax to me and doing this for a workflow that can run on multiple branches on the same time is more complicated, so I want to test it for the daily release first, just to be safe.

GHA docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow