### PR TITLE
[no-bug] Suggested Glean build.gradle config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,18 +1,8 @@
-buildscript {
-    repositories {
-        maven {
-            url = uri("https://maven.mozilla.org/maven2")
-        }
-
-        dependencies {
-            classpath("org.mozilla.components:tooling-glean-gradle:54.0.0")
-        }
-    }
-}
-
 plugins {
     id("org.mozilla.social.android.application")
     id("org.mozilla.social.android.application.compose")
+    libs.plugins.jetbrains.python
+    libs.plugins.glean.gradle.plugin
 }
 
 android {
@@ -118,5 +108,5 @@ dependencies {
 
     implementation(libs.jakewharton.timber)
 
-    testImplementation(libs.glean.analytics)
+    testImplementation(libs.glean.forUnitTests)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,8 @@ timber = "5.0.1"
 junit-junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
-mozilla-firefox-component = "54.0.0"
+glean = "54.0.0"
+jetbrains-python = "0.0.31"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
@@ -85,9 +86,8 @@ protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref 
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 square-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
-glean = { group = "org.mozilla.components", name = "service-glean", version.ref = "mozilla-firefox-component" }
-glean-tooling-gradle = { group = "org.mozilla.components", name = "tooling-glean-gradle", version.ref = "mozilla-firefox-component" }
-glean-analytics = { group = "org.mozilla.telemetry", name = "glean-native-forUnitTests", version.ref = "mozilla-firefox-component" }
+glean = { group = "org.mozilla.telemetry", name = "glean", version.ref = "glean" }
+glean-forUnitTests = { group = "org.mozilla.telemetry", name = "glean-native-forUnitTests", version.ref = "glean" }
 
 # Dependencies of build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -106,3 +106,5 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKsp" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+glean-gradle-plugin = { id = "org.mozilla.telemetry.glean-gradle-plugin", version.ref = "glean" }
+jetbrains-python = { id = "com.jetbrains.python.envs", version.ref = "jetbrains-python" }


### PR DESCRIPTION
Instead of getting Glean from Android Components, this includes it as a direct dependency (which is also available from the Mozilla maven instance). This also adds the dependency for jetbrains-python where necessary.