### PR TITLE
build(deps): use compose's material3 version declared in the compose bom

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ androidxMedia3 = "1.1.0"
 androidxPaging = "3.2.0"
 androidxRoom = "2.5.2"
 coil = "2.4.0"
-composeMaterial3 = "1.1.1"
 googleAndroidMaterial = "1.9.0"
 koin = "3.4.0"
 junit = "4.13.2"
@@ -40,7 +39,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidxComposeCompiler" } # Not used anywhere, but lets tools like Renovate or IDE warnings work by understanding what we use this version for.
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "junit" }


### PR DESCRIPTION
material3 is included in Compose BOM, so no need for us to declare the version separately (unless upgrading ahead of BOM) or for renovate to update the version separately

https://developer.android.com/jetpack/compose/bom/bom-mapping
https://developer.android.com/jetpack/compose/bom