### PR TITLE
[no bug] Move Glean and Jetbrains-Python-Envs back to buildscript

### DIFF
--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -1,9 +1,17 @@
+buildscript {
+    dependencies {
+        classpath("gradle.plugin.com.jetbrains.python:gradle-python-envs:0.0.31")
+        classpath("org.mozilla.telemetry:glean-gradle-plugin:54.0.0")
+    }
+}
+
 plugins {
     id("org.mozilla.social.android.library")
     id("org.mozilla.social.android.library.secrets")
-    alias(libs.plugins.jetbrains.python)
-    alias(libs.plugins.glean.gradle.plugin)
 }
+
+apply(plugin = "com.jetbrains.python.envs")
+apply(plugin = "org.mozilla.telemetry.glean-gradle-plugin")
 
 android {
     namespace = "org.mozilla.social.core.analytics"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,12 +9,13 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         google()
         mavenCentral()
         maven { url = uri("https://nexus.outadoc.fr/repository/public") }
         maven { url = uri("https://maven.mozilla.org/maven2") }
+        maven { url = uri("https://plugins.gradle.org/m2/") }
     }
 }
 rootProject.name = "Mozilla Social"


### PR DESCRIPTION
The only way I ended up getting this to work required moving the import back to the buildscript and applying the plugins directly. That step also required relaxing the repositories mode from failing on project repository definitions to "prefer settings". 

I'm not particularly happy with how this integrates with the newer "DSL" gradle syntax and will be filing a bug to investigate improvements to Glean docs and the gradle-plugin to help with this.