### PR TITLE
build(renovate): disable automatic ksp updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
         # See: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Hosted-Tool-Cache
     - name: Set up Gradle
       uses: gradle/gradle-build-action@v2.8.0
+    - name: Verify KSP version
+      run: ci/verify-ksp-version.sh
     - name: Compile a debug build
       env:
         GRADLE_OPTS: -Dorg.gradle.daemon=false

--- a/ci/verify-ksp-version.sh
+++ b/ci/verify-ksp-version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Fail if any commands fails.
+set -e
+
+# usage: findVersion <VERSION_NAME>
+# Looks for the given version in Gradle Version Catalog (libs.versions.toml file).
+findVersion() {
+  local NAME=$1
+  local VERSION=$(sed -nr "s/$NAME = \"([^\"]+)\"/\1/p" gradle/libs.versions.toml)
+  if [[ -z "$VERSION" ]]; then
+    echo "$NAME version not found"
+    exit 1
+  fi
+
+  RETURN="$VERSION"
+}
+
+findVersion "kotlinKsp"
+KSP_VERSION=$RETURN
+findVersion "kotlin"
+KOTLIN_VERSION=$RETURN
+
+# KSP version has to start with currently used Kotlin version.
+if [[ "$KSP_VERSION" =~ ^"$KOTLIN_VERSION" ]]; then
+  echo "KSP version matches Kotlin version"
+else
+  echo "KSP version ($KSP_VERSION) doesn't match Kotlin version ($KOTLIN_VERSION)"
+  exit 1
+fi

--- a/renovate-readme.md
+++ b/renovate-readme.md
@@ -7,13 +7,14 @@ We're using the Renovate bot, based on a common Pocket configuration: https://gi
 Because JSON doesn't support comments, this readme walks through any customization we apply
 on top of Pocket configuration.
 
-### Disable Kotlin updates
+### Disable Kotlin and KSP updates
 ```json
 {
   "packageRules": [
     {
       "matchSourceUrls": [
-        "https://github.com/JetBrains/kotlin"
+        "https://github.com/JetBrains/kotlin",
+        "https://github.com/google/ksp"
       ],
       "enabled": false
     }
@@ -21,21 +22,28 @@ on top of Pocket configuration.
 }
 ```
 
-This rule disables updating Kotlin.
+This rule disables updating Kotlin and Kotlin Symbol Processing.
 
 The reason is we're using Jetpack Compose and each Compose compiler version requires a specific
 Kotlin version. See: https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 
+KSP versions are also tied to Kotlin versions. In this case it is more obvious as KSP version
+includes Kotlin version it targets.
+
 This means we can only update Kotlin by updating Compose compiler at the same time.
 This usually means we can't use a new Kotlin version as soon as it drops. We have to wait for
-a Compose compiler update.
+a Compose compiler update. Looks like KSP releases more often than Kotlin.
+But we decided that it's not critical for us to be on the latest KSP version all the time,
+so to simplify we will only bump KSP whenever we bump Kotlin.
 
 To update Kotlin/Compose compiler:
 * Wait for renovate to detect a new Compose compiler version.
 * Let renovate open a PR with Compose compiler update.
 * Manually push a commit to renovate's branch to also update Kotlin to
   [a matching version](https://developer.android.com/jetpack/androidx/releases/compose-kotlin).
-* Then the branch should compile. Review, test and verify as normal and then merge.
+* Then the branch should compile.
+* Manually push a commit to also update KSP to the latest version matching the new Kotlin version.
+* Review, test and verify as normal and then merge.
 
 Here's an example PR upgrading Compose compiler to 1.5.0 and Kotlin to 1.9.0:
 https://github.com/Pocket/MozillaSocialAndroid/pull/59

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Pocket/renovate-config"
+    "github>Pocket/renovate-config"
   ],
   "packageRules": [
     {
       "matchSourceUrls": [
-        "https://github.com/JetBrains/kotlin"
+        "https://github.com/JetBrains/kotlin",
+        "https://github.com/google/ksp"
       ],
       "enabled": false
     }


### PR DESCRIPTION
As discussed on Slack, KSP versions are tied to Kotlin versions and renovate is not aware of that by default. John and I agreed we don't need to stay on top of latest KSP all the time, so to simplify:
* disabled KSP update PRs from renovate,
* added a GHA step to check if KSP and Kotlin versions match,
* we have to manually bump Kotlin, because Compose compiler depends on a specific version, so we'll also manually bump KSP any time we bump Kotlin (the above GHA check will make sure we don't forget).