### PR TITLE
build(gha): cancel in-progress pr checks if a new commit is pushed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,11 @@ name: pr
 on:
   pull_request
 
+# Cancel in-progress/pending PR checks if a new commit is pushed to the branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   compile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Verified that the `concurrency` block worked for daily workflows, so configuring the same for PRs. Note that this one is slightly different, because it needs to account for running multiple PR workflows at the same time **for different branches** (if two people push to their PRs at the same time).