### PR TITLE
docs: move contributing guidelines to a dedicated contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributor guidelines
+
+Before opening a PR please open an issue first, describe the bug you want to fix
+or a feature you want to implement, mention you'd like to work on it and discuss it with us.
+Thanks!
+
+# Coding Rules
+
+* Our module structure is based on [nowinandroid](https://github.com/android/nowinandroid)
+* Repositories should contain data-repository logic of reconciling different data sources (local, remote, etc.).
+  They should mirror the underlying API, so as to avoid complicated data merging
+* More complex data transformation should happen in a use case in the domain module
+* For logging we're using timber. Use it directly. Don't introduce a custom `Log` interface, don't inject it as a dependency.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # MozillaSocialAndroid
 
-## Contributing Guidelines
-
-- Our module structure is based on [nowinandroid](https://github.com/android/nowinandroid)
-- Repositories should contain data-repository logic of reconciling different data sources (local, remote, etc.). They should mirror the underlying API, so as to avoid complicated data merging
-- More complex data transformation should happen in a use case in the domain module
+Android client for [mozilla.social](https://mozilla.social) in early stages of development.
 
 ## Ruby
 


### PR DESCRIPTION
This is just basic setup:
* init'ing `CONTRIBUTING.md` with some basic language asking to discuss in an issue first,
* moving the existing coding rules from the main `README.md`,
* adding the timber rule we agreed upon on zoom and summarised on slack, but never documented permanently.

Will open a separate one that is more opinionated and possibly warrants discussion.