### PR TITLE
Profile status tabs

### DIFF
--- a/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
@@ -77,12 +77,16 @@ class AccountRepository internal constructor(
         olderThanId: String? = null,
         immediatelyNewerThanId: String? = null,
         loadSize: Int? = null,
+        onlyMedia: Boolean = false,
+        excludeReplies: Boolean = false,
     ): List<Status> =
         accountApi.getAccountStatuses(
             accountId = accountId,
             olderThanId = olderThanId,
             immediatelyNewerThanId = immediatelyNewerThanId,
             limit = loadSize,
+            onlyMedia = onlyMedia,
+            excludeReplies = excludeReplies,
         ).map { it.toExternalModel() }
 
     suspend fun getAccountBookmarks(): List<Status> =

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoTab.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoTab.kt
@@ -1,0 +1,85 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabPosition
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun MoSoTabRow(
+    selectedTabIndex: Int,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MoSoTheme.colors.layer1,
+    contentColor: Color = TabRowDefaults.contentColor,
+    indicator: @Composable (tabPositions: List<TabPosition>) -> Unit = @Composable { tabPositions ->
+        if (selectedTabIndex < tabPositions.size) {
+            TabRowDefaults.Indicator(
+                modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                color = MoSoTheme.colors.borderAccent,
+            )
+        }
+    },
+    divider: @Composable () -> Unit = @Composable {
+        Divider()
+    },
+    tabs: @Composable () -> Unit
+) {
+    TabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        indicator = indicator,
+        divider = divider,
+        tabs = tabs
+    )
+}
+
+@Composable
+fun MoSoTab(
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    selectedContentColor: Color = MoSoTheme.colors.textPrimary,
+    unselectedContentColor: Color = MoSoTheme.colors.textPrimary,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Tab(
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        selectedContentColor = selectedContentColor,
+        unselectedContentColor = unselectedContentColor,
+        interactionSource = interactionSource,
+        content = content
+    )
+}
+
+@Preview
+@Composable
+private fun TabRowPreview() {
+    MoSoTheme {
+        MoSoTabRow(selectedTabIndex = 0) {
+            MoSoTab(selected = true, onClick = { /*TODO*/ }) {
+                Text(text = "test")
+            }
+            MoSoTab(selected = false, onClick = { /*TODO*/ }) {
+                Text(text = "test2")
+            }
+        }
+    }
+}

--- a/core/domain/src/main/java/org/mozilla/social/core/domain/AccountIdBlocking.kt
+++ b/core/domain/src/main/java/org/mozilla/social/core/domain/AccountIdBlocking.kt
@@ -1,0 +1,33 @@
+package org.mozilla.social.core.domain
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * The account ID of the logged in user
+ *
+ * So much depends on this value, trying out a blocking call to simplify the rest of the code.
+ *
+ * Uses a mutex so we can cancel the flow collection after we get the value.
+ */
+class AccountIdBlocking(
+    private val accountIdFlow: AccountIdFlow,
+) {
+
+    operator fun invoke(): String = runBlocking {
+        var value = ""
+
+        val mutex = Mutex(true)
+        val job = launch {
+            accountIdFlow().collect {
+                value = it
+                mutex.unlock()
+            }
+        }
+        mutex.lock()
+        job.cancel()
+
+        value
+    }
+}

--- a/core/domain/src/main/java/org/mozilla/social/core/domain/DomainModule.kt
+++ b/core/domain/src/main/java/org/mozilla/social/core/domain/DomainModule.kt
@@ -1,7 +1,6 @@
 package org.mozilla.social.core.domain
 
 import org.koin.dsl.module
-import org.mozilla.social.core.domain.remotemediators.AccountTimelineRemoteMediator
 import org.mozilla.social.core.domain.remotemediators.HashTagTimelineRemoteMediator
 import org.mozilla.social.core.domain.remotemediators.HomeTimelineRemoteMediator
 
@@ -10,14 +9,6 @@ val domainModule = module {
     factory { parametersHolder ->
         HashTagTimelineRemoteMediator(
             get(),
-            get(),
-            get(),
-            get(),
-            parametersHolder[0]
-        )
-    }
-    factory { parametersHolder ->
-        AccountTimelineRemoteMediator(
             get(),
             get(),
             get(),

--- a/core/domain/src/main/java/org/mozilla/social/core/domain/DomainModule.kt
+++ b/core/domain/src/main/java/org/mozilla/social/core/domain/DomainModule.kt
@@ -30,4 +30,5 @@ val domainModule = module {
     single { IsSignedInFlow(get()) }
     single { AccountIdFlow(get()) }
     single { GetDetailedAccount(get(), get()) }
+    single { AccountIdBlocking(get()) }
 }

--- a/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
+++ b/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
@@ -57,6 +57,8 @@ interface AccountApi {
         @Query("min_id") immediatelyNewerThanId: String? = null,
         // Maximum number of results to return. Defaults to 20 statuses. Max 40 statuses.
         @Query("limit") limit: Int? = null,
+        @Query("only_media") onlyMedia: Boolean = false,
+        @Query("exclude_replies") excludeReplies: Boolean = false,
     ): List<NetworkStatus>
 
     @GET("/api/v1/bookmarks")

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
@@ -46,7 +46,7 @@ import org.mozilla.social.core.ui.pullrefresh.rememberPullRefreshState
 fun PostCardList(
     feed: Flow<PagingData<PostCardUiState>>,
     errorToastMessage: SharedFlow<StringFactory>,
-    refreshSignalFlow: SharedFlow<Any>? = null,
+    refreshSignalFlow: Flow<Any>? = null,
     postCardInteractions: PostCardInteractions,
     pullToRefreshEnabled: Boolean = false,
     isFullScreenLoading: Boolean = false,

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -33,6 +34,7 @@ import org.mozilla.social.core.ui.pullrefresh.rememberPullRefreshState
  * Shows a list of post cards and various loading and error states.
  *
  * @param errorToastMessage a flow of toast messages to show when an error happens
+ * @param refreshSignalFlow a flow that causes the list to refresh when it's emitted to
  * @param pullToRefreshEnabled if true, the user will be able to pull to refresh, and
  * the pull to refresh loading indicator will be used when doing an initial load or a refresh.
  * @param isFullScreenLoading if false, loading and error states will appear below the header
@@ -44,6 +46,7 @@ import org.mozilla.social.core.ui.pullrefresh.rememberPullRefreshState
 fun PostCardList(
     feed: Flow<PagingData<PostCardUiState>>,
     errorToastMessage: SharedFlow<StringFactory>,
+    refreshSignalFlow: SharedFlow<Any>? = null,
     postCardInteractions: PostCardInteractions,
     pullToRefreshEnabled: Boolean = false,
     isFullScreenLoading: Boolean = false,
@@ -51,6 +54,12 @@ fun PostCardList(
 ) {
 
     val lazyingPagingItems: LazyPagingItems<PostCardUiState> = feed.collectAsLazyPagingItems()
+
+    LaunchedEffect(Unit) {
+        refreshSignalFlow?.collect {
+            lazyingPagingItems.refresh()
+        }
+    }
 
     val pullRefreshState = rememberPullRefreshState(
         refreshing = lazyingPagingItems.loadState.refresh == LoadState.Loading,

--- a/feature/account/build.gradle.kts
+++ b/feature/account/build.gradle.kts
@@ -60,4 +60,6 @@ dependencies {
     implementation(libs.androidx.paging.runtime)
 
     implementation(libs.jakewharton.timber)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountInteractions.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountInteractions.kt
@@ -6,4 +6,5 @@ interface AccountInteractions : OverflowInteractions {
     fun onFollowClicked() = Unit
     fun onUnfollowClicked() = Unit
     fun onRetryClicked() = Unit
+    fun onTabClicked(timelineType: TimelineType) = Unit
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountModule.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountModule.kt
@@ -17,4 +17,13 @@ val accountModule = module {
             parametersHolder[2],
         )
     }
+    factory { parametersHolder ->
+        AccountTimelineRemoteMediator(
+            get(),
+            get(),
+            get(),
+            parametersHolder[0],
+            parametersHolder[1],
+        )
+    }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountTimelineRemoteMediator.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountTimelineRemoteMediator.kt
@@ -108,9 +108,3 @@ class AccountTimelineRemoteMediator(
         }
     }
 }
-
-enum class TimelineType {
-    POSTS,
-    POSTS_AND_REPLIES,
-    MEDIA,
-}

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
@@ -204,4 +204,8 @@ class AccountViewModel(
     override fun onRetryClicked() {
         loadAccount()
     }
+
+    override fun onTabClicked(timelineType: TimelineType) {
+        _timelineType.edit { timelineType }
+    }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
@@ -8,17 +8,12 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import androidx.paging.map
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
 import org.koin.core.parameter.parametersOf
 import org.koin.java.KoinJavaComponent
 import org.mozilla.social.common.Resource
@@ -31,9 +26,7 @@ import org.mozilla.social.core.data.repository.model.status.toExternalModel
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.database.model.statusCollections.toStatusWrapper
 import org.mozilla.social.core.domain.AccountIdBlocking
-import org.mozilla.social.core.domain.AccountIdFlow
 import org.mozilla.social.core.domain.GetDetailedAccount
-import org.mozilla.social.core.domain.remotemediators.AccountTimelineRemoteMediator
 import org.mozilla.social.core.ui.R
 import org.mozilla.social.core.ui.postcard.PostCardDelegate
 import org.mozilla.social.core.ui.postcard.PostCardNavigation
@@ -45,7 +38,7 @@ class AccountViewModel(
     accountIdBlocking: AccountIdBlocking,
     log: Log,
     statusRepository: StatusRepository,
-    socialDatabase: SocialDatabase,
+    private val socialDatabase: SocialDatabase,
     private val getDetailedAccount: GetDetailedAccount,
     initialAccountId: String?,
     postCardNavigation: PostCardNavigation,
@@ -86,9 +79,15 @@ class AccountViewModel(
 
     private var getAccountJob: Job? = null
 
+    private val _timelineType = MutableStateFlow(TimelineType.POSTS)
+    val timelineType = _timelineType.asStateFlow()
+
     private val accountTimelineRemoteMediator: AccountTimelineRemoteMediator by KoinJavaComponent.inject(
         AccountTimelineRemoteMediator::class.java
-    ) { parametersOf(accountId) }
+    ) { parametersOf(
+        accountId,
+        timelineType,
+    ) }
 
     @OptIn(ExperimentalPagingApi::class)
     val feed = Pager(

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
@@ -30,6 +30,7 @@ import org.mozilla.social.core.data.repository.StatusRepository
 import org.mozilla.social.core.data.repository.model.status.toExternalModel
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.database.model.statusCollections.toStatusWrapper
+import org.mozilla.social.core.domain.AccountIdBlocking
 import org.mozilla.social.core.domain.AccountIdFlow
 import org.mozilla.social.core.domain.GetDetailedAccount
 import org.mozilla.social.core.domain.remotemediators.AccountTimelineRemoteMediator
@@ -41,7 +42,7 @@ import timber.log.Timber
 
 class AccountViewModel(
     private val accountRepository: AccountRepository,
-    accountIdFlow: AccountIdFlow,
+    accountIdBlocking: AccountIdBlocking,
     log: Log,
     statusRepository: StatusRepository,
     socialDatabase: SocialDatabase,
@@ -64,26 +65,8 @@ class AccountViewModel(
 
     /**
      * The account ID of the logged in user
-     *
-     * So much depends on this value, trying out a blocking call to simplify the rest of the code.
-     *
-     * Uses a mutex so we can cancel the flow collection after we get the value.
      */
-    private val usersAccountId: String = runBlocking {
-        var value = ""
-
-        val mutex = Mutex(true)
-        val job = launch {
-            accountIdFlow().collect {
-                value = it
-                mutex.unlock()
-            }
-        }
-        mutex.lock()
-        job.cancel()
-
-        value
-    }
+    private val usersAccountId: String = accountIdBlocking()
 
     /**
      * if an account Id was passed in the constructor, the use that,

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/TimelineType.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/TimelineType.kt
@@ -1,0 +1,11 @@
+package org.mozilla.social.feature.account
+
+import org.mozilla.social.common.utils.StringFactory
+
+enum class TimelineType(
+    val tabTitle: StringFactory
+) {
+    POSTS(StringFactory.resource(R.string.tab_posts)),
+    POSTS_AND_REPLIES(StringFactory.resource(R.string.tab_posts_and_replies)),
+    MEDIA(StringFactory.resource(R.string.tab_media)),
+}

--- a/feature/account/src/main/res/values/strings.xml
+++ b/feature/account/src/main/res/values/strings.xml
@@ -17,4 +17,8 @@
     <string name="follow_button">Follow</string>
     <string name="unfollow_button">Unfollow</string>
     <string name="edit_button">Edit</string>
+
+    <string name="tab_posts">Posts</string>
+    <string name="tab_posts_and_replies">Posts and Replies</string>
+    <string name="tab_media">Media</string>
 </resources>


### PR DESCRIPTION
- Adding tabs in the profile screen for Posts, Posts and Replies, and Media
  - They all share the same database table.  When switching tabs we do a refresh that causes the table to clear and new data to load (in the remote mediator)
- Moved some code around
![Screenshot_20231005_125257](https://github.com/MozillaSocial/mozilla-social-android/assets/14130581/cf137ba2-f9d4-415b-87d8-41a31fed9239)
