### PR TITLE
build: setup detekt

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,25 @@
+name: Setup environment
+description: Common environment setup steps for all workflows
+inputs:
+  jdk:
+    description: Set up JDK
+    required: false
+    default: 'true'
+  gradle:
+    description: Set up Gradle
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+  - name: Set up JDK
+    if: ${{ inputs.jdk || inputs.gradle }}
+    uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+    with:
+      java-version: '17'
+      distribution: 'temurin'
+      # Using 'temurin' speeds up the job, because this distribution is cached by the runner.
+      # See: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Hosted-Tool-Cache
+  - name: Set up Gradle
+    if: ${{ inputs.gradle }}
+    uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,18 +14,23 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-    - name: Set up JDK
-      uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        # Using 'temurin' speeds up the job, because this distribution is cached by the runner.
-        # See: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Hosted-Tool-Cache
-    - name: Set up Gradle
-      uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+    - name: Setup
+      uses: ./.github/actions/setup-environment
     - name: Verify KSP version
       run: ci/verify-ksp-version.sh
     - name: Compile a debug build
       env:
         GRADLE_OPTS: -Dorg.gradle.daemon=false
       run: ci/debug-build.sh
+
+  detekt:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Setup
+      uses: ./.github/actions/setup-environment
+    - name: Run Detekt
+      env:
+        GRADLE_OPTS: -Dorg.gradle.daemon=false
+      run: ci/detekt.sh

--- a/app/config/detekt/baseline.xml
+++ b/app/config/detekt/baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>EmptyFunctionBlock:SplashScreen.kt${ }</ID>
+    <ID>MatchingDeclarationName:KoinTest.kt$CheckModulesTest : KoinTest</ID>
+    <ID>MaxLineLength:AppState.kt$AppState$NavigationDestination::class.sealedSubclasses.firstOrNull { it.objectInstance?.route == backStackEntry.destination.route }?.objectInstance</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -33,6 +33,7 @@ tasks.withType<KotlinCompile>().configureEach {
 dependencies {
     implementation(libs.android.gradlePlugin)
     implementation(libs.android.secrets.gradlePlugin)
+    implementation(libs.detekt.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
 }
 

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -27,6 +27,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.application")
                 apply("org.jetbrains.kotlin.android")
+                apply("org.mozilla.social.detekt")
             }
 
             extensions.configure<ApplicationExtension> {

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -26,6 +26,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.android")
+                apply("org.mozilla.social.detekt")
             }
 
             extensions.configure<LibraryExtension> {

--- a/build-logic/convention/src/main/kotlin/org/mozilla/social/ExtensionAccessors.kt
+++ b/build-logic/convention/src/main/kotlin/org/mozilla/social/ExtensionAccessors.kt
@@ -2,11 +2,16 @@ package org.mozilla.social
 
 import com.android.build.api.dsl.CommonExtension
 import com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPluginExtension
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 
 fun Project.android(configure: Action<CommonExtension<*, *, *, *, *>>) {
     extensions.configure("android", configure)
+}
+
+fun Project.detekt(configure: Action<DetektExtension>) {
+    extensions.configure("detekt", configure)
 }
 
 fun Project.secrets(configure: Action<SecretsPluginExtension>) {

--- a/build-logic/convention/src/main/kotlin/org/mozilla/social/detekt.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/org/mozilla/social/detekt.gradle.kts
@@ -1,0 +1,13 @@
+package org.mozilla.social
+
+plugins {
+    id("io.gitlab.arturbosch.detekt")
+}
+
+detekt {
+    toolVersion = libs.findVersion("detekt").get().toString()
+    parallel = true
+    config.setFrom("${rootDir}/config/detekt/detekt.yml")
+    buildUponDefaultConfig = true
+    baseline = file("config/detekt/baseline.xml")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.android.secrets) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.detekt) apply false
 }

--- a/ci/detekt.sh
+++ b/ci/detekt.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Fail if any commands fails.
+set -e
+
+./gradlew detekt --continue

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,36 @@
+complexity:
+  LongParameterList:
+    active: false # Carried over from Pocket configuration.
+    # Relaxing this to a smaller degree is recommended for Compose anyway.
+  TooManyFunctions:
+    active: false # Carried over from Pocket configuration.
+
+exceptions:
+  TooGenericExceptionCaught:
+    active: false # Carried over from Pocket configuration.
+
+naming:
+  FunctionNaming:
+    ignoreAnnotated:
+    - 'Composable' # Recommended configuration for Compose.
+  TopLevelPropertyNaming:
+    # Default pattern is '[A-Z][_A-Z0-9]*' (ALL_CAPS_SNAKE_CASE).
+    # Recommended configuration for Compose is changing the pattern to '[A-Z][A-Za-z0-9]*' (UppercaseCamelCase).
+    # We currently use both, so the pattern below allows both.
+    constantPattern: '[A-Z][_A-Za-z0-9]*'
+
+performance:
+  SpreadOperator:
+    active: false # Carried over from Pocket configuration.
+
+style:
+  MagicNumber:
+    ignorePropertyDeclaration: true # Recommended configuration for Compose.
+    ignoreCompanionObjectPropertyDeclaration: true # Recommended configuration for Compose.
+  NewLineAtEndOfFile:
+    active: false # Carried over from Pocket configuration.
+  UnusedPrivateMember:
+    ignoreAnnotated:
+    - 'Preview' # Recommended configuration for Compose.
+  WildcardImport:
+    active: false # Carried over from Pocket configuration.

--- a/core/common/config/detekt/baseline.xml
+++ b/core/common/config/detekt/baseline.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>MagicNumber:DateTimeExtensions.kt$24</ID>
+    <ID>MagicNumber:DateTimeExtensions.kt$60</ID>
+    <ID>MagicNumber:FileUtils.kt$8192</ID>
+    <ID>PrintStackTrace:FileUtils.kt$e</ID>
+    <ID>ReturnCount:TextFieldValueExtensions.kt$fun TextFieldValue.findSymbolText(symbol: Char): String?</ID>
+    <ID>ReturnCount:TextFieldValueExtensions.kt$fun TextFieldValue.replaceSymbolText(symbol: Char, newText: String): TextFieldValue</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/database/config/detekt/baseline.xml
+++ b/core/database/config/detekt/baseline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>MagicNumber:SocialDatabase.kt$SocialDatabase$3</ID>
+    <ID>MagicNumber:SocialDatabase.kt$SocialDatabase$4</ID>
+    <ID>MagicNumber:SocialDatabase.kt$SocialDatabase$5</ID>
+    <ID>MaxLineLength:DatabaseHistory.kt$DatabaseHistory$val</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/datastore/config/detekt/baseline.xml
+++ b/core/datastore/config/detekt/baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>UnusedPrivateProperty:UserPreferencesDatastore.kt$private val UserPreferences.mastodonInstance: MastodonInstance? get() = if (clientId != null &amp;&amp; clientSecret != null) { MastodonInstance(clientId = clientId, clientSecret = clientSecret) } else null</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/designsystem/config/detekt/baseline.xml
+++ b/core/designsystem/config/detekt/baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>MatchingDeclarationName:MoSoColor.kt$FirefoxColor</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/domain/config/detekt/baseline.xml
+++ b/core/domain/config/detekt/baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>LongMethod:HashTagTimelineRemoteMediator.kt$HashTagTimelineRemoteMediator$override suspend fun load( loadType: LoadType, state: PagingState&lt;Int, HashTagTimelineStatusWrapper&gt; ): MediatorResult</ID>
+    <ID>MagicNumber:HashTagTimelineRemoteMediator.kt$HashTagTimelineRemoteMediator$200</ID>
+    <ID>MagicNumber:HomeTimelineRemoteMediator.kt$HomeTimelineRemoteMediator$200</ID>
+    <ID>ReturnCount:HashTagTimelineRemoteMediator.kt$HashTagTimelineRemoteMediator$override suspend fun load( loadType: LoadType, state: PagingState&lt;Int, HashTagTimelineStatusWrapper&gt; ): MediatorResult</ID>
+    <ID>ReturnCount:HomeTimelineRemoteMediator.kt$HomeTimelineRemoteMediator$override suspend fun load( loadType: LoadType, state: PagingState&lt;Int, HomeTimelineStatusWrapper&gt; ): MediatorResult</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/model/config/detekt/baseline.xml
+++ b/core/model/config/detekt/baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>MaxLineLength:History.kt$History$val</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/network/config/detekt/baseline.xml
+++ b/core/network/config/detekt/baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>MagicNumber:NetworkModule.kt$30</ID>
+    <ID>MaxLineLength:NetworkHistory.kt$NetworkHistory$val</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/ui/config/detekt/baseline.xml
+++ b/core/ui/config/detekt/baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:PostCardList.kt$@Composable fun PostCardList( feed: Flow&lt;PagingData&lt;PostCardUiState&gt;&gt;, errorToastMessage: SharedFlow&lt;StringFactory&gt;, refreshSignalFlow: Flow&lt;Any&gt;? = null, postCardInteractions: PostCardInteractions, pullToRefreshEnabled: Boolean = false, isFullScreenLoading: Boolean = false, headerContent: @Composable () -&gt; Unit = {}, )</ID>
+    <ID>ForbiddenComment:PullRefreshIndicatorTransform.kt$// TODO: Consider whether the state parameter should be replaced with lambdas.</ID>
+    <ID>LongMethod:PostCardList.kt$@Composable fun PostCardList( feed: Flow&lt;PagingData&lt;PostCardUiState&gt;&gt;, errorToastMessage: SharedFlow&lt;StringFactory&gt;, refreshSignalFlow: Flow&lt;Any&gt;? = null, postCardInteractions: PostCardInteractions, pullToRefreshEnabled: Boolean = false, isFullScreenLoading: Boolean = false, headerContent: @Composable () -&gt; Unit = {}, )</ID>
+    <ID>LongMethod:RecommendationCard.kt$@Composable fun RecommendationCarouselCard(modifier: Modifier, recommendation: Recommendation)</ID>
+    <ID>LongMethod:VideoPlayer.kt$@SuppressLint("UnsafeOptInUsageError") @Composable fun VideoPlayer( uri: Uri, loadState: LoadState = LoadState.LOADED, )</ID>
+    <ID>LongMethod:VisibilityDropDown.kt$@Composable fun VisibilityDropDownButton( visibility: StatusVisibility, onVisibilitySelected: (StatusVisibility) -&gt; Unit, )</ID>
+    <ID>MagicNumber:MediaDisplay.kt$3</ID>
+    <ID>MagicNumber:MediaDisplay.kt$4</ID>
+    <ID>MagicNumber:Overlay.kt$0xAA000000</ID>
+    <ID>MagicNumber:PollMapping.kt$100</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$0.25f</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$0.4f</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$0.5f</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$3</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$360</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$4</ID>
+    <ID>MagicNumber:PullRefreshIndicator.kt$5</ID>
+    <ID>MagicNumber:PullRefreshState.kt$PullRefreshState$4</ID>
+    <ID>MagicNumber:RecommendationCarousel.kt$1.2f</ID>
+    <ID>MaxLineLength:HtmlContentMovementMethod.kt$HtmlContentMovementMethod$if</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/account/config/detekt/baseline.xml
+++ b/feature/account/config/detekt/baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>LongMethod:AccountScreen.kt$@Composable private fun AccountScreen( resource: Resource&lt;AccountUiState&gt;, closeButtonVisible: Boolean, isUsersProfile: Boolean, feed: Flow&lt;PagingData&lt;PostCardUiState&gt;&gt;, errorToastMessage: SharedFlow&lt;StringFactory&gt;, timelineTypeFlow: StateFlow&lt;TimelineType&gt;, accountNavigationCallbacks: AccountNavigationCallbacks, htmlContentInteractions: HtmlContentInteractions, postCardInteractions: PostCardInteractions, accountInteractions: AccountInteractions, )</ID>
+    <ID>LongMethod:AccountScreen.kt$@Composable private fun OverflowMenu( account: AccountUiState, isUsersProfile: Boolean, overflowInteractions: OverflowInteractions, )</ID>
+    <ID>LongMethod:AccountTimelineRemoteMediator.kt$AccountTimelineRemoteMediator$override suspend fun load( loadType: LoadType, state: PagingState&lt;Int, AccountTimelineStatusWrapper&gt; ): MediatorResult</ID>
+    <ID>MagicNumber:AccountTimelineRemoteMediator.kt$AccountTimelineRemoteMediator$200</ID>
+    <ID>ReturnCount:AccountTimelineRemoteMediator.kt$AccountTimelineRemoteMediator$override suspend fun load( loadType: LoadType, state: PagingState&lt;Int, AccountTimelineStatusWrapper&gt; ): MediatorResult</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/feed/config/detekt/baseline.xml
+++ b/feature/feed/config/detekt/baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>EmptyCatchBlock:FeedViewModel.kt$FeedViewModel${ }</ID>
+    <ID>SwallowedException:FeedViewModel.kt$FeedViewModel$exception: Exception</ID>
+    <ID>UnusedPrivateProperty:FeedViewModel.kt$FeedViewModel$private val currentFeedType = MutableStateFlow(INITIAL_FEED).also { viewModelScope.launch { it.collect { feedType -&gt; when (feedType) { FeedType.HOME -&gt; {} FeedType.LOCAL -&gt; {} } } } }</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/followers/config/detekt/baseline.xml
+++ b/feature/followers/config/detekt/baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>LongMethod:FollowersScreen.kt$@Composable private fun FollowersScreen( followersScreenType: FollowerScreenType, followers: Flow&lt;PagingData&lt;AccountQuickViewUiState&gt;&gt;, followersInteractions: FollowersInteractions, )</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/post/config/detekt/baseline.xml
+++ b/feature/post/config/detekt/baseline.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>LongMethod:NewPostScreen.kt$@Composable private fun BottomBar( onUploadImageClicked: () -&gt; Unit, addImageButtonEnabled: Boolean, statusText: String, contentWarningText: String?, pollInteractions: PollInteractions, pollButtonEnabled: Boolean, contentWarningInteractions: ContentWarningInteractions, )</ID>
+    <ID>LongMethod:NewPostScreen.kt$@Composable private fun NewPostScreen( statusText: TextFieldValue, statusInteractions: StatusInteractions, onPostClicked: () -&gt; Unit, onCloseClicked: () -&gt; Unit, sendButtonEnabled: Boolean, imageStates: Map&lt;Uri, ImageState&gt;, addImageButtonEnabled: Boolean, mediaInteractions: MediaInteractions, isSendingPost: Boolean, visibility: StatusVisibility, onVisibilitySelected: (StatusVisibility) -&gt; Unit, poll: Poll?, pollInteractions: PollInteractions, pollButtonEnabled: Boolean, contentWarningText: String?, contentWarningInteractions: ContentWarningInteractions, accounts: List&lt;Account&gt;?, hashTags: List&lt;String&gt;?, inReplyToAccountName: String?, )</ID>
+    <ID>LongMethod:NewPostScreen.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable private fun MainBox( statusText: TextFieldValue, statusInteractions: StatusInteractions, imageStates: Map&lt;Uri, ImageState&gt;, mediaInteractions: MediaInteractions, poll: Poll?, pollInteractions: PollInteractions, contentWarningText: String?, contentWarningInteractions: ContentWarningInteractions, inReplyToAccountName: String?, )</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.FIVE_MINUTES$300</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.ONE_DAY$86_400</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.ONE_HOUR$3_600</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.ONE_WEEK$604_800</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.SIX_HOURS$21_600</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.THIRTY_MINUTES$1_800</ID>
+    <ID>MagicNumber:PollDuration.kt$PollDuration.THREE_DAYS$259_200</ID>
+    <ID>MagicNumber:StatusDelegate.kt$StatusDelegate$500</ID>
+    <ID>MaxLineLength:StatusDelegate.kt$StatusDelegate$if (textFieldValue.text.length + (contentWarningText.value?.length ?: 0) &gt; NewPostViewModel.MAX_POST_LENGTH) return</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/report/config/detekt/baseline.xml
+++ b/feature/report/config/detekt/baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>LongMethod:ReportScreen.kt$@Composable private fun MainContent( reportTarget: ReportTarget, instanceRules: List&lt;InstanceRule&gt;, selectedReportType: ReportType?, checkedRules: List&lt;InstanceRule&gt;, additionalCommentText: String, reportInteractions: ReportInteractions, )</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/search/config/detekt/baseline.xml
+++ b/feature/search/config/detekt/baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>EmptyFunctionBlock:SearchScreen.kt${ }</ID>
+    <ID>UnusedParameter:SearchScreen.kt$viewModel: SearchViewModel = koinViewModel()</ID>
+    <ID>UnusedPrivateProperty:SearchViewModel.kt$SearchViewModel$private val timelineRepository: TimelineRepository</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/feature/settings/config/detekt/baseline.xml
+++ b/feature/settings/config/detekt/baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>MagicNumber:SettingsScreen.kt$8</ID>
+    <ID>UnusedParameter:SettingsScreen.kt$isToggled: Boolean</ID>
+    <ID>UnusedParameter:SettingsScreen.kt$onSwitchToggled: () -&gt; Unit</ID>
+    <ID>UnusedPrivateMember:SettingsScreen.kt$@Composable private fun SettingsTextLink( @DrawableRes icon: Int, @StringRes iconDesc: Int, @StringRes name: Int, onClick: () -&gt; Unit )</ID>
+    <ID>UnusedPrivateProperty:SettingsViewModel.kt$SettingsViewModel$private val log: Log</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-media3 = "1.1.0"
 androidx-paging = "3.2.0"
 androidx-room = "2.5.2"
 coil = "2.4.0"
+detekt = "1.23.1"
 koin = "3.4.0"
 kotlin = "1.9.10"
 kotlin-ksp = "1.9.10-1.0.13" # Used only once, but keeping this definition makes the KSP version check at ci/verify-ksp-version.sh simpler.
@@ -78,6 +79,7 @@ square-okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", v
 # Dependencies of build-logic
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 android-secrets-gradlePlugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "android-secrets-plugin" }
+detekt-gradlePlugin = { module = "io.gitlab.arturbosch.detekt:io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
 glean-gradlePlugin = { module = "org.mozilla.telemetry:glean-gradle-plugin", version.ref = "glean" }
 jetbrains-python-gradlePlugin = { module = "gradle.plugin.com.jetbrains.python:gradle-python-envs", version.ref = "jetbrains-python" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -89,6 +91,7 @@ espresso-core = { group = "androidx.test.espresso", name = "espresso-core", vers
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 android-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "android-secrets-plugin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}


### PR DESCRIPTION
## Implementation decisions
* Added a Detekt convention plugin and applied it in our android app/library convention plugins.
  * This means Detekt is enabled for all modules by default. If we ever don't want it enabled for a module, we can look into providing an opt out.
  * This means Detekt runs for each module separately, not as a single task that analyses all Kotlin files in the repository. You can still run `./gradlew detekt` to run it for all modules in one command.
  * This means each module gets its own baseline file.
* I used the `buildUponDefaultConfig` option to keep our config minimal, easier to maintain as rules are deprecated/migrated in future versions and so it's clearer where we use default settings and where we customise.
* I created the config by merging Detekt's own recommendations for Compose projects and some customisations we used at Pocket. This is very much open to further tweaking, either as part of this review or future PRs.
* Since our GHA workflows started duplicating common setup steps a lot, I learned about custom composite actions and added one to solve this.

## References
* https://github.com/detekt/detekt
* https://detekt.dev/docs/gettingstarted/gradle
* https://github.com/Pocket/Android/pull/1718
* https://github.com/Pocket/Android/blob/e86118c98d6f9bcd0e2a19ad0eee9478f80fde17/config/detekt/detekt.yml
