### PR TITLE
chore(deps): clean up version catalog and applying plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,5 +7,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.android.secrets) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.glean) apply false
+    alias(libs.plugins.jetbrains.python) apply false
     alias(libs.plugins.detekt) apply false
 }

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -1,17 +1,9 @@
-buildscript {
-    dependencies {
-        classpath(libs.glean.gradlePlugin)
-        classpath(libs.jetbrains.python.gradlePlugin)
-    }
-}
-
 plugins {
     id("org.mozilla.social.android.library")
     id("org.mozilla.social.android.library.secrets")
+    alias(libs.plugins.jetbrains.python)
+    alias(libs.plugins.glean)
 }
-
-apply(plugin = libs.plugins.jetbrains.python.get().pluginId)
-apply(plugin = libs.plugins.glean.gradle.plugin.get().pluginId)
 
 android {
     namespace = "org.mozilla.social.core.analytics"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,23 +7,12 @@ androidx-paging = "3.2.0"
 androidx-room = "2.5.2"
 coil = "2.4.0"
 detekt = "1.23.1"
+glean = "54.0.0"
 koin = "3.4.0"
 kotlin = "1.9.10"
 kotlin-ksp = "1.9.10-1.0.13" # Used only once, but keeping this definition makes the KSP version check at ci/verify-ksp-version.sh simpler.
 okhttp = "4.10.0"
 protobuf = "3.23.0"
-protobufPlugin = "0.9.3"
-retrofit = "2.9.0"
-timber = "5.0.1"
-junit-junit = "4.13.2"
-androidx-test-ext-junit = "1.1.5"
-espresso-core = "3.5.1"
-glean = "54.0.0"
-mozilla-components = "118.0"
-jetbrains-python = "0.0.31"
-junit = "4.13.2"
-androidx-test-ext-junit115 = "1.1.5"
-androidx-test-espresso-espresso-core = "3.5.1"
 
 
 [libraries]
@@ -56,8 +45,8 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 coil-video = { module = "io.coil-kt:coil-video", version.ref = "coil" }
-glean = { group = "org.mozilla.telemetry", name = "glean", version.ref = "glean" }
-glean-forUnitTests = { group = "org.mozilla.telemetry", name = "glean-native-forUnitTests", version.ref = "glean" }
+glean = { module = "org.mozilla.telemetry:glean", version.ref = "glean" }
+glean-forUnitTests = { module = "org.mozilla.telemetry:glean-native-forUnitTests", version.ref = "glean" }
 google-material = { module = "com.google.android.material:material", version = "1.9.0" }
 jakewharton-timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 koin = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
@@ -69,7 +58,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.0" }
 kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version = "1.0.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.5.1" }
-mozilla-components-service-glean = { group = "org.mozilla.components", name = "service-glean", version.ref = "mozilla-components" }
+mozilla-components-service-glean = { module = "org.mozilla.components:service-glean", version = "118.0" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version = "2.9.0" }
@@ -80,21 +69,16 @@ square-okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", v
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 android-secrets-gradlePlugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "android-secrets-plugin" }
 detekt-gradlePlugin = { module = "io.gitlab.arturbosch.detekt:io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
-glean-gradlePlugin = { module = "org.mozilla.telemetry:glean-gradle-plugin", version.ref = "glean" }
-jetbrains-python-gradlePlugin = { module = "gradle.plugin.com.jetbrains.python:gradle-python-envs", version.ref = "jetbrains-python" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit115" }
-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso-espresso-core" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 android-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "android-secrets-plugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+glean = { id = "org.mozilla.telemetry.glean-gradle-plugin", version.ref = "glean" }
+jetbrains-python = { id = "com.jetbrains.python.envs", version = "0.0.31" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
-protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
-glean-gradle-plugin = { id = "org.mozilla.telemetry.glean-gradle-plugin", version.ref = "glean" }
-jetbrains-python = { id = "com.jetbrains.python.envs", version.ref = "jetbrains-python" }
+protobuf = { id = "com.google.protobuf", version = "0.9.3" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,17 @@ pluginManagement {
         google()
         mavenCentral()
         maven { url = uri("https://maven.mozilla.org/maven2") }
-        maven { url = uri("https://plugins.gradle.org/m2/") }
+        gradlePluginPortal()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            // Manually resolve Glean plugin ID to Maven coordinates,
+            // because the Maven repository is missing plugin marker artifacts.
+            // See: https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_resolution_rules
+            if (requested.id.id == "org.mozilla.telemetry.glean-gradle-plugin") {
+                useModule("org.mozilla.telemetry:glean-gradle-plugin:${requested.version}")
+            }
+        }
     }
 }
 
@@ -13,7 +23,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url = uri("https://nexus.outadoc.fr/repository/public") }
         maven { url = uri("https://maven.mozilla.org/maven2") }
     }
 }


### PR DESCRIPTION
Wanted to just reformat `libs.versions.toml` according to our recently introduced [rules](https://github.com/MozillaSocial/mozilla-social-android/blob/main/CONTRIBUTING.md#dependencies). While I was there I figured out a cleaner way to apply the plugins added for Glean.