### PR TITLE
removing kotlin reflect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,8 +64,6 @@ dependencies {
     implementation(project(":feature:followers"))
     implementation(project(":core:navigation"))
 
-    implementation(kotlin("reflect"))
-
     // android
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)

--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -76,7 +76,7 @@ fun rememberAppState(
  */
 @OptIn(ExperimentalMaterial3Api::class)
 class AppState(
-    initialTopLevelDestination: NavigationDestination = NavigationDestination.Feed,
+    initialTopLevelDestination: String = NavigationDestination.Feed.route,
     val navController: NavHostController, // Don't access this other than for initializing the nav host
     val topAppBarScrollBehavior: TopAppBarScrollBehavior,
     val navigationDrawerState: DrawerState,
@@ -87,9 +87,9 @@ class AppState(
 ) {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val currentNavigationDestination: StateFlow<NavigationDestination?> =
+    val currentNavigationRoute: StateFlow<String?> =
         navController.currentBackStackEntryFlow.mapLatest { backStackEntry ->
-            NavigationDestination::class.sealedSubclasses.firstOrNull { it.objectInstance?.route == backStackEntry.destination.route }?.objectInstance
+            backStackEntry.destination.route
         }.stateIn(
             coroutineScope,
             started = SharingStarted.WhileSubscribed(),

--- a/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
+++ b/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
@@ -39,7 +39,7 @@ import org.mozilla.social.ui.navigationdrawer.NavigationDrawer
 fun MainActivityScreen() {
     val appState = rememberAppState()
 
-    val currentRoute = appState.currentNavigationDestination.collectAsState().value
+    val currentRoute = appState.currentNavigationRoute.collectAsState().value
 
     MoSoScaffold(
         modifier = Modifier.nestedScroll(appState.topAppBarScrollBehavior.nestedScrollConnection),
@@ -83,11 +83,11 @@ fun MainActivityScreen() {
 
 @Composable
 private fun FloatingActionButton(
-    currentDestination: NavigationDestination?,
+    currentDestination: String?,
     onClick: () -> Unit,
 ) {
     when (currentDestination) {
-        NavigationDestination.Feed -> {
+        NavigationDestination.Feed.route -> {
             androidx.compose.material3.FloatingActionButton(onClick = onClick) {
                 Icon(
                     MoSoIcons.Add,
@@ -102,16 +102,16 @@ private fun FloatingActionButton(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TopBar(
-    currentDestination: NavigationDestination?,
+    currentDestination: String?,
     topAppBarScrollBehavior: TopAppBarScrollBehavior,
     navigationDrawerState: DrawerState,
 ) {
     val coroutineScope = rememberCoroutineScope()
 
     when (currentDestination) {
-        NavigationDestination.Feed,
-        NavigationDestination.Search,
-        NavigationDestination.Bookmarks -> {
+        NavigationDestination.Feed.route,
+        NavigationDestination.Search.route,
+        NavigationDestination.Bookmarks.route -> {
             Column {
                 MoSoAppBar(
                     scrollBehavior = topAppBarScrollBehavior,
@@ -150,11 +150,11 @@ private fun TopBar(
 
 @Composable
 private fun BottomBar(
-    currentDestination: NavigationDestination?,
+    currentDestination: String?,
     navigateToTopLevelDestination: (route: String) -> Unit,
 ) {
     // don't show bottom bar if our current route is not one of the bottom nav options
-    if (BottomBarTabs.values().find { it.bottomBarTab.navigationDestination == currentDestination } == null) {
+    if (BottomBarTabs.values().find { it.bottomBarTab.navigationDestination.route == currentDestination } == null) {
         return
     }
 

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoNavigationBar.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoNavigationBar.kt
@@ -30,7 +30,7 @@ import org.mozilla.social.core.navigation.NavigationDestination
 @Composable
 fun MoSoBottomNavigationBar(
     modifier: Modifier = Modifier,
-    currentDestination: NavigationDestination,
+    currentDestination: String,
     bottomBarTabs: List<BottomBarTab>,
     navigateTo: (route: String) -> Unit,
     containerColor: Color = MoSoNavigationBarDefaults.containerColor,
@@ -48,7 +48,7 @@ fun MoSoBottomNavigationBar(
         bottomBarTabs.forEach { navBarDestination ->
             MoSoNavigationBarItem(
                 destination = navBarDestination,
-                isSelected = currentDestination == navBarDestination.navigationDestination,
+                isSelected = currentDestination == navBarDestination.navigationDestination.route,
                 navigateTo = navigateTo,
             )
         }


### PR DESCRIPTION
- Removed kotlin reflect
I tried adding the sealed class to the proguard file, but got this error `Sealed classes are not supported as program classes when generating class files`
So I ended up just removing reflection and making the `AppState.currentNavigationRoute` be a flow of a string that we can compare to nav destination route strings instead.