### PR TITLE
Report updates part 1

### DIFF
--- a/app/src/main/java/org/mozilla/social/navigation/MozillaNavHost.kt
+++ b/app/src/main/java/org/mozilla/social/navigation/MozillaNavHost.kt
@@ -13,7 +13,7 @@ import org.mozilla.social.feature.auth.loginScreen
 import org.mozilla.social.feature.followers.followersScreen
 import org.mozilla.social.feature.followers.followingScreen
 import org.mozilla.social.feature.hashtag.hashTagScreen
-import org.mozilla.social.feature.report.reportScreen
+import org.mozilla.social.feature.report.reportFlow
 import org.mozilla.social.feature.settings.settingsScreen
 import org.mozilla.social.feature.thread.threadScreen
 import org.mozilla.social.feed.feedScreen
@@ -74,9 +74,10 @@ private fun NavGraphBuilder.mainGraph(
             onCloseClicked = { appState.popBackStack() },
             postCardNavigation = appState.postCardNavigation,
         )
-        reportScreen(
-            onReported = { appState.popBackStack() },
+        reportFlow(
+            onDoneClicked = { appState.popBackStack() },
             onCloseClicked = { appState.popBackStack() },
+            navController = appState.navController,
         )
         hashTagScreen(
             onCloseClicked = { appState.popBackStack() },

--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -99,8 +99,15 @@ class AppState(
     val postCardNavigation = object : PostCardNavigation {
         override fun onReplyClicked(statusId: String) = navigateToNewPost(statusId)
         override fun onPostClicked(statusId: String) = navigateToThread(statusId)
-        override fun onReportClicked(accountId: String, statusId: String) =
-            navigateToReport(accountId, statusId)
+        override fun onReportClicked(
+            accountId: String,
+            accountHandle: String,
+            statusId: String,
+        ) = navigateToReport(
+            accountId = accountId,
+            accountHandle = accountHandle,
+            statusId = statusId,
+        )
 
         override fun onAccountClicked(accountId: String) = navigateToAccount(accountId)
         override fun onHashTagClicked(hashTag: String) = navigateToHashTag(hashTag)
@@ -120,7 +127,13 @@ class AppState(
         override fun onFollowersClicked(accountId: String) =
             navigateToAccountFollowers(accountId)
         override fun onCloseClicked() = popBackStack()
-        override fun onReportClicked(accountId: String) = navigateToReport(accountId)
+        override fun onReportClicked(
+            accountId: String,
+            accountHandle: String,
+        ) = navigateToReport(
+            accountId = accountId,
+            accountHandle = accountHandle
+        )
     }
 
     val followersNavigation = object : FollowersNavigationCallbacks {
@@ -200,9 +213,14 @@ class AppState(
 
     fun navigateToReport(
         accountId: String,
+        accountHandle: String,
         statusId: String? = null
     ) {
-        navController.navigateToReport(reportAccountId = accountId, reportStatusId = statusId)
+        navController.navigateToReport(
+            reportAccountId = accountId,
+            reportAccountHandle = accountHandle,
+            reportStatusId = statusId,
+        )
     }
 
     fun navigateToHashTag(hashTag: String) {

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoCheckbox.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoCheckbox.kt
@@ -1,0 +1,64 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxColors
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun MoSoCheckBox(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: CheckboxColors = MoSoCheckboxDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    Checkbox(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+        interactionSource = interactionSource,
+    )
+}
+
+object MoSoCheckboxDefaults {
+    @Composable
+    fun colors(): CheckboxColors = CheckboxDefaults.colors(
+        checkedColor = MoSoTheme.colors.iconActionActive,
+        uncheckedColor = MoSoTheme.colors.iconActionDisabled,
+        checkmarkColor = MoSoTheme.colors.textActionPrimary,
+        disabledCheckedColor = MoSoTheme.colors.iconActionActive,
+        disabledUncheckedColor = MoSoTheme.colors.iconActionDisabled,
+        disabledIndeterminateColor = MoSoTheme.colors.textActionPrimary,
+    )
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    MoSoTheme {
+        MoSoSurface {
+            MoSoCheckBox(checked = true, onCheckedChange = {})
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewDarkMode() {
+    MoSoTheme(
+        darkTheme = true
+    ) {
+        MoSoSurface {
+            MoSoCheckBox(checked = true, onCheckedChange = {})
+        }
+    }
+}

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoRadioButton.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoRadioButton.kt
@@ -1,0 +1,62 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonColors
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun MoSoRadioButton(
+    selected: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: RadioButtonColors = MoSoRadioButtonDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    RadioButton(
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+        interactionSource = interactionSource
+    )
+}
+
+object MoSoRadioButtonDefaults {
+    @Composable
+    fun colors() : RadioButtonColors = RadioButtonDefaults.colors(
+        selectedColor = MoSoTheme.colors.iconActionActive,
+        unselectedColor = MoSoTheme.colors.iconActionDisabled,
+        disabledSelectedColor = MoSoTheme.colors.iconActionActive,
+        disabledUnselectedColor = MoSoTheme.colors.iconActionDisabled,
+    )
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    MoSoTheme {
+        MoSoSurface {
+            MoSoRadioButton(selected = true, onClick = null)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewDarkMode() {
+    MoSoTheme(
+        darkTheme = true
+    ) {
+        MoSoSurface {
+            MoSoRadioButton(selected = true, onClick = null)
+        }
+    }
+}

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoTextField.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoTextField.kt
@@ -1,0 +1,96 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun MoSoTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = TextFieldDefaults.shape,
+    colors: TextFieldColors = MoSoTextFieldDefaults.colors()
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .border(
+                width = 1.dp,
+                color = MoSoTheme.colors.borderInputEnabled,
+                shape = RoundedCornerShape(16.dp)
+        ),
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = textStyle,
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        prefix = prefix,
+        suffix = suffix,
+        supportingText = supportingText,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = colors
+    )
+}
+
+object MoSoTextFieldDefaults {
+    @Composable
+    fun colors(): TextFieldColors = TextFieldDefaults.colors(
+        cursorColor = MoSoTheme.colors.textActionPrimary,
+        unfocusedLabelColor = MoSoTheme.colors.textSecondary,
+        focusedLabelColor = MoSoTheme.colors.textSecondary,
+        disabledLabelColor = MoSoTheme.colors.textSecondary,
+        errorLabelColor = MoSoTheme.colors.textWarning,
+        focusedContainerColor = Color.Transparent,
+        focusedIndicatorColor = Color.Transparent,
+        unfocusedIndicatorColor = Color.Transparent,
+        disabledIndicatorColor = Color.Transparent,
+        disabledContainerColor = Color.Transparent,
+        errorContainerColor = Color.Transparent,
+        unfocusedContainerColor = Color.Transparent,
+    )
+}

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/theme/MoSoTheme.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/theme/MoSoTheme.kt
@@ -89,6 +89,7 @@ private val darkColorPalette = MoSoColors(
     borderForm = FirefoxColor.LightGrey05,
     borderAccent = FirefoxColor.Violet30,
     borderWarning = FirefoxColor.Red20,
+    borderInputEnabled = FirefoxColor.DarkGrey05,
 )
 
 private val lightColorPalette = MoSoColors(
@@ -115,6 +116,7 @@ private val lightColorPalette = MoSoColors(
     borderForm = FirefoxColor.DarkGrey90,
     borderAccent = FirefoxColor.Violet60,
     borderWarning = FirefoxColor.Red70,
+    borderInputEnabled = FirefoxColor.LightGrey60,
 )
 
 
@@ -145,6 +147,7 @@ class MoSoColors(
     borderForm: Color,
     borderAccent: Color,
     borderWarning: Color,
+    borderInputEnabled: Color,
 ) {
     // Layers
 
@@ -242,6 +245,9 @@ class MoSoColors(
     var borderWarning by mutableStateOf(borderWarning)
         private set
 
+    var borderInputEnabled by mutableStateOf(borderInputEnabled)
+        private set
+
     fun update(other: MoSoColors) {
         layer1 = other.layer1
         layer2 = other.layer2
@@ -264,6 +270,7 @@ class MoSoColors(
         borderFormDefault = other.borderFormDefault
         borderAccent = other.borderAccent
         borderWarning = other.borderWarning
+        borderInputEnabled = other.borderInputEnabled
     }
 
     /**
@@ -291,6 +298,7 @@ class MoSoColors(
         borderFormDefault: Color = this.borderFormDefault,
         borderAccent: Color = this.borderAccent,
         borderWarning: Color = this.borderWarning,
+        borderInputEnabled: Color = this.borderInputEnabled,
     ): MoSoColors = MoSoColors(
         layer1 = layer1,
         layer2 = layer2,
@@ -313,6 +321,7 @@ class MoSoColors(
         borderForm = borderFormDefault,
         borderAccent = borderAccent,
         borderWarning = borderWarning,
+        borderInputEnabled = borderInputEnabled,
     )
 }
 

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/theme/MoSoTheme.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/theme/MoSoTheme.kt
@@ -82,6 +82,8 @@ private val darkColorPalette = MoSoColors(
     iconPrimary = FirefoxColor.LightGrey05,
     iconSecondary = FirefoxColor.LightGrey40,
     iconAccent = FirefoxColor.Violet30,
+    iconActionActive = FirefoxColor.Violet20,
+    iconActionDisabled = FirefoxColor.LightGrey70,
 
     borderPrimary = FirefoxColor.DarkGrey05,
     borderForm = FirefoxColor.LightGrey05,
@@ -106,6 +108,8 @@ private val lightColorPalette = MoSoColors(
     iconPrimary = FirefoxColor.DarkGrey90,
     iconSecondary = FirefoxColor.DarkGrey05,
     iconAccent = FirefoxColor.Violet60,
+    iconActionActive = FirefoxColor.Violet60,
+    iconActionDisabled = FirefoxColor.LightGrey70,
 
     borderPrimary = FirefoxColor.LightGrey40,
     borderForm = FirefoxColor.DarkGrey90,
@@ -135,6 +139,8 @@ class MoSoColors(
     iconPrimary: Color,
     iconSecondary: Color,
     iconAccent: Color,
+    iconActionActive: Color,
+    iconActionDisabled: Color,
     borderPrimary: Color,
     borderForm: Color,
     borderAccent: Color,
@@ -212,6 +218,12 @@ class MoSoColors(
     var iconAccentViolet by mutableStateOf(iconAccent)
         private set
 
+    var iconActionActive by mutableStateOf(iconActionActive)
+        private set
+
+    var iconActionDisabled by mutableStateOf(iconActionDisabled)
+        private set
+
     // Border
 
     // Default, Divider, Dotted
@@ -246,6 +258,8 @@ class MoSoColors(
         iconPrimary = other.iconPrimary
         iconSecondary = other.iconSecondary
         iconAccentViolet = other.iconAccentViolet
+        iconActionActive = other.iconActionActive
+        iconActionDisabled = other.iconActionDisabled
         borderPrimary = other.borderPrimary
         borderFormDefault = other.borderFormDefault
         borderAccent = other.borderAccent
@@ -271,6 +285,8 @@ class MoSoColors(
         iconPrimary: Color = this.iconPrimary,
         iconSecondary: Color = this.iconSecondary,
         iconAccentViolet: Color = this.iconAccentViolet,
+        iconActionActive: Color = this.iconActionActive,
+        iconActionDisabled: Color = this.iconActionDisabled,
         borderPrimary: Color = this.borderPrimary,
         borderFormDefault: Color = this.borderFormDefault,
         borderAccent: Color = this.borderAccent,
@@ -291,6 +307,8 @@ class MoSoColors(
         iconPrimary = iconPrimary,
         iconSecondary = iconSecondary,
         iconAccent = iconAccentViolet,
+        iconActionActive = iconActionActive,
+        iconActionDisabled = iconActionDisabled,
         borderPrimary = borderPrimary,
         borderForm = borderFormDefault,
         borderAccent = borderAccent,

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
@@ -94,11 +94,11 @@ sealed class NavigationDestination(
     )
 
     data object ReportScreen2: NavigationDestination(
-        route = "report1"
+        route = "report2"
     )
 
     data object ReportScreen3: NavigationDestination(
-        route = "report1"
+        route = "report3"
     )
 
     data object Search: NavigationDestination(

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
@@ -73,20 +73,24 @@ sealed class NavigationDestination(
     ) {
         const val NAV_PARAM_REPORT_STATUS_ID = "reportStatusId"
         const val NAV_PARAM_REPORT_ACCOUNT_ID = "reportAccountId"
+        const val NAV_PARAM_REPORT_ACCOUNT_HANDLE = "reportAccountHandle"
         val fullRoute = "$route?" +
                 "$NAV_PARAM_REPORT_STATUS_ID={$NAV_PARAM_REPORT_STATUS_ID}" +
-                "&$NAV_PARAM_REPORT_ACCOUNT_ID={$NAV_PARAM_REPORT_ACCOUNT_ID}"
+                "&$NAV_PARAM_REPORT_ACCOUNT_ID={$NAV_PARAM_REPORT_ACCOUNT_ID}" +
+                "&$NAV_PARAM_REPORT_ACCOUNT_HANDLE={$NAV_PARAM_REPORT_ACCOUNT_HANDLE}"
 
         fun route(
             reportAccountId: String,
+            reportAccountHandle: String,
             reportStatusId: String? = null,
-        ): String =
-            when {
-                reportStatusId != null -> "$route?" +
-                        "$NAV_PARAM_REPORT_STATUS_ID=$reportStatusId" +
-                        "&$NAV_PARAM_REPORT_ACCOUNT_ID=$reportAccountId"
-                else -> "$route?$NAV_PARAM_REPORT_ACCOUNT_ID=$reportAccountId"
-            }
+        ): String = "$route?" +
+                "$NAV_PARAM_REPORT_ACCOUNT_ID=$reportAccountId" +
+                "&$NAV_PARAM_REPORT_ACCOUNT_HANDLE=$reportAccountHandle" +
+                if (reportStatusId != null) {
+                    "&$NAV_PARAM_REPORT_STATUS_ID=$reportStatusId"
+                } else {
+                    ""
+                }
     }
 
     data object ReportScreen1: NavigationDestination(

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
@@ -89,6 +89,18 @@ sealed class NavigationDestination(
             }
     }
 
+    data object ReportScreen1: NavigationDestination(
+        route = "report1"
+    )
+
+    data object ReportScreen2: NavigationDestination(
+        route = "report1"
+    )
+
+    data object ReportScreen3: NavigationDestination(
+        route = "report1"
+    )
+
     data object Search: NavigationDestination(
         route = "search"
     )

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
@@ -162,7 +162,13 @@ private fun MetaData(
                 DropDownItem(
                     text = stringResource(id = R.string.report_user, post.username),
                     expanded = overflowMenuExpanded,
-                    onClick = { postCardInteractions.onOverflowReportClicked(post.accountId, post.statusId) }
+                    onClick = {
+                        postCardInteractions.onOverflowReportClicked(
+                            post.accountId,
+                            post.accountName.build(context),
+                            post.statusId,
+                        )
+                    }
                 )
             }
         }

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardDelegate.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardDelegate.kt
@@ -102,8 +102,16 @@ class PostCardDelegate(
         }
     }
 
-    override fun onOverflowReportClicked(accountId: String, statusId: String) {
-        postCardNavigation.onReportClicked(accountId, statusId)
+    override fun onOverflowReportClicked(
+        accountId: String,
+        accountHandle: String,
+        statusId: String,
+    ) {
+        postCardNavigation.onReportClicked(
+            accountId = accountId,
+            accountHandle = accountHandle,
+            statusId = statusId,
+        )
     }
 
     override fun onAccountImageClicked(accountId: String) {

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardInteractions.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardInteractions.kt
@@ -10,6 +10,10 @@ interface PostCardInteractions : PollInteractions, HtmlContentInteractions {
     fun onPostCardClicked(statusId: String) = Unit
     fun onOverflowMuteClicked(accountId: String) = Unit
     fun onOverflowBlockClicked(accountId: String) = Unit
-    fun onOverflowReportClicked(accountId: String, statusId: String) = Unit
+    fun onOverflowReportClicked(
+        accountId: String,
+        accountHandle: String,
+        statusId: String,
+    ) = Unit
     fun onAccountImageClicked(accountId: String) = Unit
 }

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardNavigation.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardNavigation.kt
@@ -3,7 +3,11 @@ package org.mozilla.social.core.ui.postcard
 interface PostCardNavigation {
     fun onReplyClicked(statusId: String) = Unit
     fun onPostClicked(statusId: String) = Unit
-    fun onReportClicked(accountId: String, statusId: String) = Unit
+    fun onReportClicked(
+        accountId: String,
+        accountHandle: String,
+        statusId: String,
+    ) = Unit
     fun onAccountClicked(accountId: String) = Unit
     fun onHashTagClicked(hashTag: String) = Unit
     fun onLinkClicked(url: String) = Unit

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountNavigationCallbacks.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountNavigationCallbacks.kt
@@ -4,5 +4,8 @@ interface AccountNavigationCallbacks {
     fun onFollowingClicked(accountId: String) = Unit
     fun onFollowersClicked(accountId: String) = Unit
     fun onCloseClicked() = Unit
-    fun onReportClicked(accountId: String) = Unit
+    fun onReportClicked(
+        accountId: String,
+        accountHandle: String,
+    ) = Unit
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
@@ -168,7 +168,12 @@ class AccountViewModel(
     }
 
     override fun onOverflowReportClicked() {
-        accountNavigationCallbacks.onReportClicked(accountId)
+        (uiState.value as? Resource.Loaded)?.data?.webFinger?.let { webFinger ->
+            accountNavigationCallbacks.onReportClicked(
+                accountId,
+                webFinger,
+            )
+        }
     }
 
     override fun onFollowersClicked() {

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportInteractions.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportInteractions.kt
@@ -8,4 +8,5 @@ interface ReportInteractions {
     fun onReportTypeSelected(reportType: ReportType) = Unit
     fun onServerRuleClicked(rule: InstanceRule) = Unit
     fun onAdditionCommentTextChanged(text: String) = Unit
+    fun onSendToExternalServerClicked() = Unit
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportModule.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportModule.kt
@@ -2,10 +2,13 @@ package org.mozilla.social.feature.report
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.feature.report.step1.ReportScreen1ViewModel
+import org.mozilla.social.feature.report.step2.ReportScreen2ViewModel
+import org.mozilla.social.feature.report.step3.ReportScreen3ViewModel
 
 val reportModule = module {
     viewModel { parametersHolder ->
-        ReportViewModel(
+        ReportScreen1ViewModel(
             get(),
             get(),
             get(),
@@ -13,6 +16,14 @@ val reportModule = module {
             parametersHolder[1],
             parametersHolder[2],
             parametersHolder[3],
+        )
+    }
+    viewModel { parametersHolder ->
+        ReportScreen2ViewModel(
+        )
+    }
+    viewModel { parametersHolder ->
+        ReportScreen3ViewModel(
         )
     }
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportModule.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportModule.kt
@@ -16,6 +16,7 @@ val reportModule = module {
             parametersHolder[1],
             parametersHolder[2],
             parametersHolder[3],
+            parametersHolder[4],
         )
     }
     viewModel { parametersHolder ->

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportNavigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportNavigation.kt
@@ -15,9 +15,17 @@ import org.mozilla.social.feature.report.step3.reportScreen3
 fun NavController.navigateToReport(
     navOptions: NavOptions? = null,
     reportAccountId: String,
+    reportAccountHandle: String,
     reportStatusId: String? = null,
 ) {
-    navigate(NavigationDestination.Report.route(reportAccountId, reportStatusId), navOptions)
+    navigate(
+        NavigationDestination.Report.route(
+            reportAccountId = reportAccountId,
+            reportAccountHandle = reportAccountHandle,
+            reportStatusId = reportStatusId,
+        ),
+        navOptions
+    )
 }
 
 fun NavGraphBuilder.reportFlow(

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportNavigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportNavigation.kt
@@ -4,8 +4,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
+import androidx.navigation.navigation
 import org.mozilla.social.core.navigation.NavigationDestination
+import org.mozilla.social.feature.report.step1.ReportScreen1
+import org.mozilla.social.feature.report.step1.reportScreen1
+import org.mozilla.social.feature.report.step2.navigateToReportScreen2
+import org.mozilla.social.feature.report.step2.reportScreen2
+import org.mozilla.social.feature.report.step3.navigateToReportScreen3
+import org.mozilla.social.feature.report.step3.reportScreen3
 
 fun NavController.navigateToReport(
     navOptions: NavOptions? = null,
@@ -15,11 +23,13 @@ fun NavController.navigateToReport(
     navigate(NavigationDestination.Report.route(reportAccountId, reportStatusId), navOptions)
 }
 
-fun NavGraphBuilder.reportScreen(
-    onReported: () -> Unit,
+fun NavGraphBuilder.reportFlow(
+    onDoneClicked: () -> Unit,
     onCloseClicked: () -> Unit,
+    navController: NavController,
 ) {
-    composable(
+    navigation(
+        startDestination = NavigationDestination.ReportScreen1.route,
         route = NavigationDestination.Report.fullRoute,
         arguments = listOf(
             navArgument(NavigationDestination.Report.NAV_PARAM_REPORT_STATUS_ID) {
@@ -28,17 +38,26 @@ fun NavGraphBuilder.reportScreen(
             navArgument(NavigationDestination.Report.NAV_PARAM_REPORT_ACCOUNT_ID) {
                 nullable = true
             }
-        )
+        ),
     ) {
-        val reportAccountId: String? = it.arguments?.getString(NavigationDestination.Report.NAV_PARAM_REPORT_ACCOUNT_ID)
-        val reportStatusId: String? = it.arguments?.getString(NavigationDestination.Report.NAV_PARAM_REPORT_STATUS_ID)
-        reportAccountId?.let {
-            ReportScreen(
-                onReported,
-                onCloseClicked,
-                reportAccountId = reportAccountId,
-                reportStatusId = reportStatusId,
-            )
-        } ?: onCloseClicked()
+        reportScreen1(
+            onDoneClicked,
+            onCloseClicked,
+            onNextClicked = { reportType ->
+                when (reportType) {
+                    ReportType.DO_NOT_LIKE -> navController.navigateToReportScreen3()
+                    else -> navController.navigateToReportScreen2()
+                }
+            }
+        )
+        reportScreen2(
+            onReportSubmitted = {
+                navController.navigateToReportScreen3()
+            }
+        )
+        reportScreen3(
+            onDoneClicked = onDoneClicked,
+        )
     }
 }
+

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportNavigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportNavigation.kt
@@ -3,12 +3,9 @@ package org.mozilla.social.feature.report
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
-import androidx.navigation.navigation
 import org.mozilla.social.core.navigation.NavigationDestination
-import org.mozilla.social.feature.report.step1.ReportScreen1
 import org.mozilla.social.feature.report.step1.reportScreen1
 import org.mozilla.social.feature.report.step2.navigateToReportScreen2
 import org.mozilla.social.feature.report.step2.reportScreen2

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportType.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportType.kt
@@ -3,6 +3,7 @@ package org.mozilla.social.feature.report
 enum class ReportType(
     val stringValue: String
 ) {
+    DO_NOT_LIKE("do not like"),
     SPAM("spam"),
     VIOLATION("violation"),
     OTHER("other"),

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -1,4 +1,4 @@
-package org.mozilla.social.feature.report
+package org.mozilla.social.feature.report.step1
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -42,15 +42,20 @@ import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.component.MoSoTopBar
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.ui.transparentTextFieldColors
+import org.mozilla.social.feature.report.R
+import org.mozilla.social.feature.report.ReportInteractions
+import org.mozilla.social.feature.report.ReportTarget
+import org.mozilla.social.feature.report.ReportType
 import org.mozilla.social.model.InstanceRule
 
 @Composable
-internal fun ReportScreen(
+internal fun ReportScreen1(
     onReported: () -> Unit,
     onCloseClicked: () -> Unit,
+    onNextClicked: (reportType: ReportType) -> Unit,
     reportAccountId: String,
     reportStatusId: String?,
-    viewModel: ReportViewModel = koinViewModel(parameters = {
+    viewModel: ReportScreen1ViewModel = koinViewModel(parameters = {
         parametersOf(
             onReported,
             onCloseClicked,
@@ -59,7 +64,7 @@ internal fun ReportScreen(
         )
     })
 ) {
-    ReportScreen(
+    ReportScreen1(
         reportTarget = if (reportStatusId != null) {
             ReportTarget.POST
         } else {
@@ -76,7 +81,7 @@ internal fun ReportScreen(
 }
 
 @Composable
-private fun ReportScreen(
+private fun ReportScreen1(
     reportTarget: ReportTarget,
     instanceRules: List<InstanceRule>,
     selectedReportType: ReportType?,
@@ -279,7 +284,7 @@ private fun CheckableInstanceRule(
 @Composable
 private fun ReportScreenPreview() {
     MoSoTheme {
-        ReportScreen(
+        ReportScreen1(
             reportTarget = ReportTarget.POST,
             instanceRules = listOf(
                 InstanceRule(

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -285,7 +285,7 @@ private fun SelectableReportType(
             Text(
                 text = title,
                 style = MoSoTheme.typography.bodyMedium,
-                fontWeight = FontWeight(700)
+                fontWeight = FontWeight.W700
             )
             content()
         }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -1,6 +1,5 @@
 package org.mozilla.social.feature.report.step1
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,11 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
@@ -32,7 +28,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.core.designsystem.component.MoSoButton
@@ -44,7 +39,6 @@ import org.mozilla.social.core.designsystem.component.MoSoTextField
 import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.component.MoSoTopBar
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
-import org.mozilla.social.core.ui.transparentTextFieldColors
 import org.mozilla.social.feature.report.R
 import org.mozilla.social.feature.report.ReportInteractions
 import org.mozilla.social.feature.report.ReportTarget

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -37,7 +37,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
+import org.mozilla.social.core.designsystem.component.MoSoButton
+import org.mozilla.social.core.designsystem.component.MoSoCheckBox
 import org.mozilla.social.core.designsystem.component.MoSoDivider
+import org.mozilla.social.core.designsystem.component.MoSoRadioButton
 import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.component.MoSoTopBar
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
@@ -159,13 +162,14 @@ private fun MainContent(
             selectedReportType = selectedReportType,
             reportInteractions = reportInteractions,
         ) {
-            instanceRules.forEach { instanceRule ->
-                CheckableInstanceRule(
-                    enabled = selectedReportType == ReportType.VIOLATION,
-                    checked = checkedRules.contains(instanceRule),
-                    instanceRule = instanceRule,
-                    reportInteractions = reportInteractions,
-                )
+            if (selectedReportType == ReportType.VIOLATION) {
+                instanceRules.forEach { instanceRule ->
+                    CheckableInstanceRule(
+                        checked = checkedRules.contains(instanceRule),
+                        instanceRule = instanceRule,
+                        reportInteractions = reportInteractions,
+                    )
+                }
             }
         }
 
@@ -198,7 +202,7 @@ private fun MainContent(
         )
         Spacer(modifier = Modifier.padding(8.dp))
 
-        Button(
+        MoSoButton(
             modifier = Modifier
                 .fillMaxWidth(),
             enabled = selectedReportType != null,
@@ -223,7 +227,7 @@ private fun SelectableReportType(
             .padding(4.dp)
             .clickable { reportInteractions.onReportTypeSelected(reportType) }
     ) {
-        RadioButton(
+        MoSoRadioButton(
             modifier = Modifier
                 .size(20.dp),
             selected = selectedReportType == reportType,
@@ -244,25 +248,21 @@ private fun SelectableReportType(
 
 @Composable
 private fun CheckableInstanceRule(
-    enabled: Boolean,
     checked: Boolean,
     instanceRule: InstanceRule,
     reportInteractions: ReportInteractions,
 ) {
     Row(
         Modifier
-            .clickable(
-                enabled = enabled
-            ) {
+            .clickable {
                 reportInteractions.onServerRuleClicked(instanceRule)
             }
             .padding(4.dp)
             .fillMaxWidth(),
     ) {
-        Checkbox(
+        MoSoCheckBox(
             modifier = Modifier
                 .size(20.dp),
-            enabled = enabled,
             checked = checked,
             onCheckedChange = { reportInteractions.onServerRuleClicked(instanceRule) }
         )
@@ -270,12 +270,6 @@ private fun CheckableInstanceRule(
         Text(
             modifier = Modifier.align(Alignment.CenterVertically),
             text = instanceRule.text,
-            color = if (enabled) {
-                Color.Unspecified
-            } else {
-                // same alpha as the disabled checkbox
-                Color.Unspecified.copy(alpha = 0.38f)
-            }
         )
     }
 }
@@ -283,17 +277,55 @@ private fun CheckableInstanceRule(
 @Preview
 @Composable
 private fun ReportScreenPreview() {
+    val noDummies = InstanceRule(
+        1,
+        "no dummies"
+    )
+    val noDogs = InstanceRule(
+        2,
+        "no dogs"
+    )
     MoSoTheme {
         ReportScreen1(
             reportTarget = ReportTarget.POST,
             instanceRules = listOf(
-                InstanceRule(
-                    1,
-                    "no dummies"
-                )
+                noDummies,
+                noDogs
             ),
-            selectedReportType = null,
-            checkedRules = listOf(),
+            selectedReportType = ReportType.VIOLATION,
+            checkedRules = listOf(
+                noDogs,
+            ),
+            additionalCommentText = "",
+            reportInteractions = object : ReportInteractions {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ReportScreenPreviewDarkMode() {
+    val noDummies = InstanceRule(
+        1,
+        "no dummies"
+    )
+    val noDogs = InstanceRule(
+        2,
+        "no dogs"
+    )
+    MoSoTheme(
+        darkTheme = true
+    ) {
+        ReportScreen1(
+            reportTarget = ReportTarget.POST,
+            instanceRules = listOf(
+                noDummies,
+                noDogs
+            ),
+            selectedReportType = ReportType.VIOLATION,
+            checkedRules = listOf(
+                noDogs,
+            ),
             additionalCommentText = "",
             reportInteractions = object : ReportInteractions {}
         )

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -148,6 +148,14 @@ private fun MainContent(
         )
         Spacer(modifier = Modifier.padding(4.dp))
         SelectableReportType(
+            reportType = ReportType.DO_NOT_LIKE,
+            title = stringResource(id = R.string.report_reason_do_not_like),
+            selectedReportType = selectedReportType,
+            reportInteractions = reportInteractions,
+        ) {
+            Text(text = stringResource(id = R.string.report_reason_do_not_like_description))
+        }
+        SelectableReportType(
             reportType = ReportType.SPAM,
             title = stringResource(id = R.string.report_reason_spam),
             selectedReportType = selectedReportType,
@@ -208,7 +216,7 @@ private fun MainContent(
             enabled = selectedReportType != null,
             onClick = { reportInteractions.onReportClicked() }
         ) {
-            Text(text = stringResource(id = R.string.report_button))
+            Text(text = stringResource(id = R.string.next_button))
         }
         Spacer(modifier = Modifier.padding(16.dp))
     }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -57,6 +57,7 @@ internal fun ReportScreen1(
     onCloseClicked: () -> Unit,
     onNextClicked: (reportType: ReportType) -> Unit,
     reportAccountId: String,
+    reportAccountHandle: String,
     reportStatusId: String?,
     viewModel: ReportScreen1ViewModel = koinViewModel(parameters = {
         parametersOf(

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
@@ -27,7 +27,6 @@ internal fun NavGraphBuilder.reportScreen1(
             return@composable
         }
         ReportScreen1(
-            onDoneClicked,
             onCloseClicked,
             onNextClicked,
             reportAccountId = reportAccountId,

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
@@ -1,4 +1,4 @@
-@file:Suppress
+@file:Suppress("detekt:all")
 package org.mozilla.social.feature.report.step1
 
 import androidx.navigation.NavGraphBuilder

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
@@ -1,3 +1,4 @@
+@file:Suppress
 package org.mozilla.social.feature.report.step1
 
 import androidx.navigation.NavGraphBuilder

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
@@ -1,9 +1,7 @@
 package org.mozilla.social.feature.report.step1
 
-import androidx.compose.runtime.remember
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
 import org.mozilla.social.core.navigation.NavigationDestination
 import org.mozilla.social.feature.report.ReportType
 
@@ -15,15 +13,10 @@ internal fun NavGraphBuilder.reportScreen1(
     composable(
         route = NavigationDestination.ReportScreen1.route,
     ) {
-        val navController = rememberNavController()
-        val reportEntry = remember(it) {
-            navController.getBackStackEntry(NavigationDestination.Report.fullRoute)
-        }
-
-        val reportAccountId: String? = reportEntry.arguments?.getString(
+        val reportAccountId: String? = it.arguments?.getString(
             NavigationDestination.Report.NAV_PARAM_REPORT_ACCOUNT_ID
         )
-        val reportStatusId: String? = reportEntry.arguments?.getString(
+        val reportStatusId: String? = it.arguments?.getString(
             NavigationDestination.Report.NAV_PARAM_REPORT_STATUS_ID
         )
         reportAccountId?.let {

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
@@ -16,17 +16,23 @@ internal fun NavGraphBuilder.reportScreen1(
         val reportAccountId: String? = it.arguments?.getString(
             NavigationDestination.Report.NAV_PARAM_REPORT_ACCOUNT_ID
         )
+        val reportAccountHandle: String? = it.arguments?.getString(
+            NavigationDestination.Report.NAV_PARAM_REPORT_ACCOUNT_HANDLE
+        )
         val reportStatusId: String? = it.arguments?.getString(
             NavigationDestination.Report.NAV_PARAM_REPORT_STATUS_ID
         )
-        reportAccountId?.let {
-            ReportScreen1(
-                onDoneClicked,
-                onCloseClicked,
-                onNextClicked,
-                reportAccountId = reportAccountId,
-                reportStatusId = reportStatusId,
-            )
-        } ?: onCloseClicked()
+        if (reportAccountId == null || reportAccountHandle == null) {
+            onCloseClicked()
+            return@composable
+        }
+        ReportScreen1(
+            onDoneClicked,
+            onCloseClicked,
+            onNextClicked,
+            reportAccountId = reportAccountId,
+            reportAccountHandle = reportAccountHandle,
+            reportStatusId = reportStatusId,
+        )
     }
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1Navigation.kt
@@ -1,0 +1,39 @@
+package org.mozilla.social.feature.report.step1
+
+import androidx.compose.runtime.remember
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import org.mozilla.social.core.navigation.NavigationDestination
+import org.mozilla.social.feature.report.ReportType
+
+internal fun NavGraphBuilder.reportScreen1(
+    onDoneClicked: () -> Unit,
+    onCloseClicked: () -> Unit,
+    onNextClicked: (reportType: ReportType) -> Unit,
+) {
+    composable(
+        route = NavigationDestination.ReportScreen1.route,
+    ) {
+        val navController = rememberNavController()
+        val reportEntry = remember(it) {
+            navController.getBackStackEntry(NavigationDestination.Report.fullRoute)
+        }
+
+        val reportAccountId: String? = reportEntry.arguments?.getString(
+            NavigationDestination.Report.NAV_PARAM_REPORT_ACCOUNT_ID
+        )
+        val reportStatusId: String? = reportEntry.arguments?.getString(
+            NavigationDestination.Report.NAV_PARAM_REPORT_STATUS_ID
+        )
+        reportAccountId?.let {
+            ReportScreen1(
+                onDoneClicked,
+                onCloseClicked,
+                onNextClicked,
+                reportAccountId = reportAccountId,
+                reportStatusId = reportStatusId,
+            )
+        } ?: onCloseClicked()
+    }
+}

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
@@ -1,4 +1,4 @@
-package org.mozilla.social.feature.report
+package org.mozilla.social.feature.report.step1
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,9 +12,12 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.common.utils.edit
 import org.mozilla.social.core.data.repository.InstanceRepository
 import org.mozilla.social.core.data.repository.ReportRepository
+import org.mozilla.social.feature.report.R
+import org.mozilla.social.feature.report.ReportInteractions
+import org.mozilla.social.feature.report.ReportType
 import org.mozilla.social.model.InstanceRule
 
-class ReportViewModel(
+class ReportScreen1ViewModel(
     private val reportRepository: ReportRepository,
     private val instanceRepository: InstanceRepository,
     private val log: Log,

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
@@ -1,3 +1,4 @@
+@file:Suppress
 package org.mozilla.social.feature.report.step1
 
 import androidx.lifecycle.ViewModel

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
@@ -1,4 +1,4 @@
-@file:Suppress
+@file:Suppress("detekt:all")
 package org.mozilla.social.feature.report.step1
 
 import androidx.lifecycle.ViewModel

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1ViewModel.kt
@@ -21,9 +21,10 @@ class ReportScreen1ViewModel(
     private val reportRepository: ReportRepository,
     private val instanceRepository: InstanceRepository,
     private val log: Log,
-    private val onReported: () -> Unit,
+    private val onNextClicked: (reportType: ReportType) -> Unit,
     private val onClose: () -> Unit,
     private val reportAccountId: String,
+    private val reportAccountHandle: String,
     private val reportStatusId: String?,
 ) : ViewModel(), ReportInteractions {
 
@@ -38,6 +39,9 @@ class ReportScreen1ViewModel(
 
     private val _additionCommentText = MutableStateFlow("")
     val additionalCommentText = _additionCommentText.asStateFlow()
+
+    private val _sendToExternalServerChecked = MutableStateFlow(false)
+    val sendToExternalServerChecked = _sendToExternalServerChecked.asStateFlow()
 
     private val _errorToastMessage = MutableSharedFlow<StringFactory>(extraBufferCapacity = 1)
     val errorToastMessage = _errorToastMessage.asSharedFlow()
@@ -61,24 +65,25 @@ class ReportScreen1ViewModel(
         onClose()
     }
 
+    //TODO move this to screen 2
     override fun onReportClicked() {
-        viewModelScope.launch {
-            try {
-                reportRepository.report(
-                    accountId = reportAccountId,
-                    statusIds = buildList {
-                        reportStatusId?.let { add(it) }
-                    },
-                    comment = additionalCommentText.value,
-                    category = selectedReportType.value?.stringValue,
-                    ruleViolations = instanceRules.value.map { it.id }
-                )
-            } catch (e: Exception) {
-                log.e(e)
-                _errorToastMessage.emit(StringFactory.resource(R.string.error_sending_report_toast))
-            }
-            onReported()
-        }
+//        viewModelScope.launch {
+//            try {
+//                reportRepository.report(
+//                    accountId = reportAccountId,
+//                    statusIds = buildList {
+//                        reportStatusId?.let { add(it) }
+//                    },
+//                    comment = additionalCommentText.value,
+//                    category = selectedReportType.value?.stringValue,
+//                    ruleViolations = instanceRules.value.map { it.id }
+//                )
+//            } catch (e: Exception) {
+//                log.e(e)
+//                _errorToastMessage.emit(StringFactory.resource(R.string.error_sending_report_toast))
+//            }
+//            onReported()
+//        }
     }
 
     override fun onReportTypeSelected(reportType: ReportType) {
@@ -103,5 +108,9 @@ class ReportScreen1ViewModel(
 
     override fun onAdditionCommentTextChanged(text: String) {
         _additionCommentText.edit { text }
+    }
+
+    override fun onSendToExternalServerClicked() {
+        _sendToExternalServerChecked.edit { !sendToExternalServerChecked.value }
     }
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
@@ -1,0 +1,24 @@
+package org.mozilla.social.feature.report.step2
+
+import androidx.compose.runtime.Composable
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+import org.mozilla.social.core.designsystem.component.MoSoButton
+
+@Composable
+internal fun ReportScreen2(
+    onReportSubmitted: () -> Unit,
+    viewModel: ReportScreen2ViewModel = koinViewModel(parameters = {
+        parametersOf(
+        )
+    })
+) {
+
+}
+
+@Composable
+private fun ReportScreen2() {
+    MoSoButton(onClick = { /*TODO*/ }) {
+
+    }
+}

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
@@ -1,4 +1,4 @@
-@file:Suppress
+@file:Suppress("detekt:all")
 package org.mozilla.social.feature.report.step2
 
 import androidx.compose.runtime.Composable

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
@@ -1,3 +1,4 @@
+@file:Suppress
 package org.mozilla.social.feature.report.step2
 
 import androidx.compose.runtime.Composable

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2Navigation.kt
@@ -1,0 +1,25 @@
+package org.mozilla.social.feature.report.step2
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import org.mozilla.social.core.navigation.NavigationDestination
+
+internal fun NavController.navigateToReportScreen2(
+    navOptions: NavOptions? = null,
+) {
+    navigate(NavigationDestination.ReportScreen2.route, navOptions)
+}
+
+internal fun NavGraphBuilder.reportScreen2(
+    onReportSubmitted: () -> Unit
+) {
+    composable(
+        route = NavigationDestination.ReportScreen2.route,
+    ) {
+        ReportScreen2(
+            onReportSubmitted = onReportSubmitted,
+        )
+    }
+}

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
@@ -1,3 +1,4 @@
+@file:Suppress
 package org.mozilla.social.feature.report.step2
 
 import androidx.lifecycle.ViewModel

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
@@ -1,0 +1,8 @@
+package org.mozilla.social.feature.report.step2
+
+import androidx.lifecycle.ViewModel
+
+class ReportScreen2ViewModel(
+
+) : ViewModel() {
+}

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
@@ -1,4 +1,4 @@
-@file:Suppress
+@file:Suppress("detekt:all")
 package org.mozilla.social.feature.report.step2
 
 import androidx.lifecycle.ViewModel

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
@@ -1,0 +1,24 @@
+package org.mozilla.social.feature.report.step3
+
+import androidx.compose.runtime.Composable
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+import org.mozilla.social.core.designsystem.component.MoSoButton
+
+@Composable
+internal fun ReportScreen3(
+    onDoneClicked: () -> Unit,
+    viewModel: ReportScreen3ViewModel = koinViewModel(parameters = {
+        parametersOf(
+        )
+    })
+) {
+
+}
+
+@Composable
+private fun ReportScreen3() {
+    MoSoButton(onClick = { /*TODO*/ }) {
+
+    }
+}

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
@@ -1,3 +1,4 @@
+@file:Suppress
 package org.mozilla.social.feature.report.step3
 
 import androidx.compose.runtime.Composable

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
@@ -1,4 +1,4 @@
-@file:Suppress
+@file:Suppress("detekt:all")
 package org.mozilla.social.feature.report.step3
 
 import androidx.compose.runtime.Composable

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3Navigation.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3Navigation.kt
@@ -1,0 +1,25 @@
+package org.mozilla.social.feature.report.step3
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import org.mozilla.social.core.navigation.NavigationDestination
+
+internal fun NavController.navigateToReportScreen3(
+    navOptions: NavOptions? = null,
+) {
+    navigate(NavigationDestination.ReportScreen3.route, navOptions)
+}
+
+internal fun NavGraphBuilder.reportScreen3(
+    onDoneClicked: () -> Unit
+) {
+    composable(
+        route = NavigationDestination.ReportScreen3.route,
+    ) {
+        ReportScreen3(
+            onDoneClicked = onDoneClicked,
+        )
+    }
+}

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3ViewModel.kt
@@ -1,3 +1,4 @@
+@file:Suppress
 package org.mozilla.social.feature.report.step3
 
 import androidx.lifecycle.ViewModel

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3ViewModel.kt
@@ -1,4 +1,4 @@
-@file:Suppress
+@file:Suppress("detekt:all")
 package org.mozilla.social.feature.report.step3
 
 import androidx.lifecycle.ViewModel

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3ViewModel.kt
@@ -1,0 +1,8 @@
+package org.mozilla.social.feature.report.step3
+
+import androidx.lifecycle.ViewModel
+
+class ReportScreen3ViewModel(
+
+) : ViewModel() {
+}

--- a/feature/report/src/main/res/values/strings.xml
+++ b/feature/report/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="report">Report</string>
     <string name="report_screen_title">@string/report</string>
 
+    <string name="report_prompt">Reporting %s</string>
+
     <string name="report_instructions_for_post">Tell us what\'s wrong with this post</string>
     <string name="report_instructions_for_account">Tell us what\'s wrong with this account</string>
 
@@ -15,6 +17,7 @@
     <string name="report_reason_spam_description">Malicious links, fake engagement, or repetitive replies.</string>
 
     <string name="report_reason_violation">It violates one or more of the server rules</string>
+    <string name="report_reason_violation_description">Select all that apply</string>
 
     <string name="report_reason_other">It\'s something else</string>
     <string name="report_reason_other_description">The issue does not fit into other categories.</string>

--- a/feature/report/src/main/res/values/strings.xml
+++ b/feature/report/src/main/res/values/strings.xml
@@ -19,6 +19,10 @@
     <string name="report_reason_other">It\'s something else</string>
     <string name="report_reason_other_description">The issue does not fit into other categories.</string>
 
+    <string name="external_instance_title">The user you\'re reporting is from another server</string>
+    <string name="external_instance_description">Do you want to send a copy of this report to that server as well?</string>
+    <string name="external_instance_option">Yes, forward this report to %s</string>
+
     <string name="extra_info_prompt">Is there anything else you think we should know?</string>
     <string name="extra_info_text_field_label">Additional comments</string>
 

--- a/feature/report/src/main/res/values/strings.xml
+++ b/feature/report/src/main/res/values/strings.xml
@@ -8,18 +8,22 @@
 
     <string name="choose_best_match">Choose the best match:</string>
 
+    <string name="report_reason_do_not_like">I don\'t like it</string>
+    <string name="report_reason_do_not_like_description">It\'s not something you want to see.</string>
+
     <string name="report_reason_spam">It\'s spam</string>
-    <string name="report_reason_spam_description">Malicious links, fake engagement, or repetitive replies</string>
+    <string name="report_reason_spam_description">Malicious links, fake engagement, or repetitive replies.</string>
 
     <string name="report_reason_violation">It violates one or more of the server rules</string>
 
     <string name="report_reason_other">It\'s something else</string>
-    <string name="report_reason_other_description">The issue does not fit into other categories</string>
+    <string name="report_reason_other_description">The issue does not fit into other categories.</string>
 
     <string name="extra_info_prompt">Is there anything else you think we should know?</string>
     <string name="extra_info_text_field_label">Additional comments</string>
 
     <string name="report_button">@string/report</string>
+    <string name="next_button">Next</string>
 
     <string name="error_sending_report_toast">Error sending report</string>
 </resources>


### PR DESCRIPTION
This PR is getting pretty big so I'm splitting this up into multiple PRs.  Here is part 1

- Creating 3 separate report screens for the report flow
  - Creating a nested navigation graph to handle the report flow.  This graph lives in the report module
- Creating report screens 1 2 and 3.  2 and 3 are currently blank and you can't get to them yet.  Report screen 1 is the screen we already had.  The view model and interactions still need some updates, that will come in the next PR
- Updating the UI for the first screen.  It now looks nice in dark mode and it's using MoSoTheme components, colors and typography
- Adding some new moso theme components
  - checkbox
  - radio button
  - text field
- Adding new moso theme colors from figma