### PR TITLE
fixing scroll issue

### DIFF
--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -89,7 +89,9 @@ class AppState(
     @OptIn(ExperimentalCoroutinesApi::class)
     val currentNavigationDestination: StateFlow<NavigationDestination?> =
         navController.currentBackStackEntryFlow.mapLatest { backStackEntry ->
-            NavigationDestination::class.sealedSubclasses.firstOrNull { it.objectInstance?.route == backStackEntry.destination.route }?.objectInstance
+            NavigationDestination::class.sealedSubclasses.firstOrNull {
+                it.objectInstance?.route == backStackEntry.destination.route
+            }?.objectInstance
         }.stateIn(
             coroutineScope,
             started = SharingStarted.WhileSubscribed(),
@@ -240,5 +242,16 @@ class AppState(
         }
 
         navController.navigate(destination, navOptions)
+    }
+
+    companion object {
+        fun shouldShowTopBar(
+            currentDestination: NavigationDestination?
+        ): Boolean = when (currentDestination) {
+            NavigationDestination.Feed,
+            NavigationDestination.Search,
+            NavigationDestination.Bookmarks -> true
+            else -> false
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
+++ b/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
@@ -40,14 +40,17 @@ import org.mozilla.social.ui.navigationdrawer.NavigationDrawer
 fun MainActivityScreen() {
     val appState = rememberAppState()
 
-    val currentRoute = appState.currentNavigationDestination.collectAsState().value
+    val currentDestination = appState.currentNavigationDestination.collectAsState().value
 
     MoSoScaffold(
-        modifier = Modifier.nestedScroll(appState.topAppBarScrollBehavior.nestedScrollConnection),
+        modifier = if (AppState.shouldShowTopBar(currentDestination)) {
+            Modifier.nestedScroll(appState.topAppBarScrollBehavior.nestedScrollConnection)
+        } else {
+            Modifier
+        },
         snackbarHost = { appState.snackbarHostState },
         floatingActionButton = {
-
-            when (currentRoute) {
+            when (currentDestination) {
                 NavigationDestination.Feed -> {
                     MoSoFloatingActionButton(onClick = appState::navigateToNewPost) {
                         Icon(
@@ -61,18 +64,17 @@ fun MainActivityScreen() {
         },
         bottomBar = {
             BottomBar(
-                currentDestination = currentRoute,
+                currentDestination = currentDestination,
                 navigateToTopLevelDestination = appState::navigateToTopLevelDestination
             )
         },
         topBar = {
             TopBar(
-                currentDestination = currentRoute,
+                currentDestination = currentDestination,
                 topAppBarScrollBehavior = appState.topAppBarScrollBehavior,
                 navigationDrawerState = appState.navigationDrawerState,
             )
         },
-        topAppBarScrollBehavior = appState.topAppBarScrollBehavior,
         navigationDrawerState = appState.navigationDrawerState,
         navigationDrawerContent = {
             NavigationDrawer(
@@ -99,43 +101,38 @@ private fun TopBar(
 ) {
     val coroutineScope = rememberCoroutineScope()
 
-    when (currentDestination) {
-        NavigationDestination.Feed,
-        NavigationDestination.Search,
-        NavigationDestination.Bookmarks -> {
-            Column {
-                MoSoAppBar(
-                    scrollBehavior = topAppBarScrollBehavior,
-                    title = {
-                        Image(
-                            painter = mozillaLogo(),
-                            contentDescription = "mozilla logo"
-                        )
-                    },
-                    navigationIcon = {
-                        IconButton(onClick = {
-                            coroutineScope.launch {
-                                navigationDrawerState.open()
-                            }
-                        }) {
-                            Icon(
-                                painter = MoSoIcons.list(),
-                                modifier = Modifier.size(24.dp),
-                                contentDescription = stringResource(id = R.string.navigation_menu_content_description),
-                            )
+    if (AppState.shouldShowTopBar(currentDestination)) {
+        Column {
+            MoSoAppBar(
+                scrollBehavior = topAppBarScrollBehavior,
+                title = {
+                    Image(
+                        painter = mozillaLogo(),
+                        contentDescription = "mozilla logo"
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        coroutineScope.launch {
+                            navigationDrawerState.open()
                         }
-                    },
-                    actions = {}
-                )
+                    }) {
+                        Icon(
+                            painter = MoSoIcons.list(),
+                            modifier = Modifier.size(24.dp),
+                            contentDescription = stringResource(id = R.string.navigation_menu_content_description),
+                        )
+                    }
+                },
+                actions = {}
+            )
 
-                MoSoDivider(
-                    modifier = Modifier
-                        .height(1.dp)
-                        .background(MoSoTheme.colors.borderPrimary)
-                )
-            }
+            MoSoDivider(
+                modifier = Modifier
+                    .height(1.dp)
+                    .background(MoSoTheme.colors.borderPrimary)
+            )
         }
-        else -> {}
     }
 }
 

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoScaffold.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoScaffold.kt
@@ -5,23 +5,18 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.DrawerState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import org.mozilla.social.core.designsystem.icon.MosSoBottomSheet
 
 /**
  * Wrapps scaffold in a navigation drawer
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoSoScaffold(
     modifier: Modifier = Modifier,
-    topAppBarScrollBehavior: TopAppBarScrollBehavior,
     topBar: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     snackbarHost: @Composable () -> Unit = {},
@@ -37,13 +32,16 @@ fun MoSoScaffold(
         drawerContent = navigationDrawerContent,
         content = {
             Scaffold(
-                modifier = modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+                modifier = modifier,
                 snackbarHost = snackbarHost,
                 floatingActionButton = { floatingActionButton() },
                 bottomBar = bottomBar,
                 topBar = topBar,
             ) {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.BottomCenter
+                ) {
                     content(it)
                     MosSoBottomSheet(visible = bottomSheetVisible, content = bottomSheetContent)
                 }


### PR DESCRIPTION
Scroll on screens that don't use the scaffold's top app bar was causing the `topAppBarScrollBehavior` to be triggered.  

- Removing the `topAppBarScrollBehavior` from the scaffold modifier when we are viewing a screen that does not use the top app bar
- Adding a companion function to determine if we should show the top app bar