### PR TITLE
Making videos / gifs not "pop in"

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.ui)
 
+    implementation(libs.jakewharton.timber)
 
     // compose
     implementation(platform(libs.androidx.compose.bom))


### PR DESCRIPTION
When scrolling up in a timeline, videos and gifs will "pop in" and push content down.  It's very jarring.  It does this because as the video player loads, the height gets set.  Before it loads the height is 0.  This can be fixed by setting a static height for videos.  But what should the height be?  If we hardcode a height, the aspect ratio could be different on different devices.  So instead, I'm just setting the aspect ratio directly.

- Making videos have an aspect ratio of 1:1
- Giving videos a rounded corner shape
- Cleaning up the video player file just a tad