### PR TITLE
Disabling drawer gesture when closed

### DIFF
--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoNavigationDrawer.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoNavigationDrawer.kt
@@ -19,6 +19,7 @@ fun MoSoNavigationDrawer(
         drawerContent = drawerContent,
         drawerState = drawerState,
         content = content,
+        gesturesEnabled = drawerState.isOpen
     )
 
 }


### PR DESCRIPTION
Currently you can open the drawer (from anywhere) by swiping right.  I'd like to remove that ability because swipes to the right can conflict with back navigation swipes, and with other horizontally scrolling elements.  And the side drawer should not be open-able from anywhere

- Disabled drawer gestures when the drawer is closed