### PR TITLE
Preventing clicking on root status in thread

### DIFF
--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
@@ -48,17 +48,28 @@ import org.mozilla.social.core.ui.media.MediaDisplay
 import org.mozilla.social.core.ui.poll.Poll
 import org.mozilla.social.core.ui.htmlcontent.HtmlContent
 
+/**
+ * @param threadId if viewing this post from a thread, pass the threadId in to prevent
+ * the user from being able to click on the same status as the root thread status
+ */
 @Composable
 fun PostCard(
     post: PostCardUiState,
     postCardInteractions: PostCardInteractions,
+    threadId: String? = null
 ) {
     NoRipple {
         Column(
             Modifier
                 .padding(8.dp)
                 .fillMaxSize()
-                .clickable { postCardInteractions.onPostCardClicked(post.mainPostCardUiState.statusId) }
+                .clickable {
+                    // prevent the user from being able to click on the same status
+                    // as the root thread status
+                    if (post.mainPostCardUiState.statusId != threadId) {
+                        postCardInteractions.onPostCardClicked(post.mainPostCardUiState.statusId)
+                    }
+                }
         ) {
             post.topRowMetaDataUiState?.let {
                 TopRowMetaData(

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
@@ -50,7 +50,7 @@ import org.mozilla.social.core.ui.htmlcontent.HtmlContent
 
 /**
  * @param threadId if viewing this post from a thread, pass the threadId in to prevent
- * the user from being able to click on the same status as the root thread status
+ * the user from being able to click on the same status as the thread's root status
  */
 @Composable
 fun PostCard(

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
@@ -197,6 +197,10 @@ private fun LazyListScope.listContent(
     }
 }
 
+/**
+ * @param threadId if viewing a thread, pass the threadId in to prevent
+ * the user from being able to click on the same status as the thread's root status
+ */
 @Composable
 fun PostCardList(
     items: List<PostCardUiState>,

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardList.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -203,6 +202,7 @@ fun PostCardList(
     items: List<PostCardUiState>,
     errorToastMessage: SharedFlow<StringFactory>,
     postCardInteractions: PostCardInteractions,
+    threadId: String? = null,
 ) {
 
     LazyColumn(
@@ -215,7 +215,11 @@ fun PostCardList(
             key = { items[it].statusId }
         ) { index ->
             val item = items[index]
-            PostCard(post = item, postCardInteractions)
+            PostCard(
+                post = item,
+                postCardInteractions = postCardInteractions,
+                threadId = threadId
+            )
             if (index < items.count()) {
                 MoSoDivider()
             }

--- a/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadScreen.kt
@@ -30,6 +30,7 @@ internal fun ThreadScreen(
             items = viewModel.statuses.collectAsState(emptyList()).value,
             errorToastMessage = viewModel.postCardDelegate.errorToastMessage,
             postCardInteractions = viewModel.postCardDelegate,
+            threadId = threadStatusId,
         )
     }
 }


### PR DESCRIPTION
- Making it so user's cannot click on a thread's root status