### PR TITLE
Screen transition animations

### DIFF
--- a/app/src/main/java/org/mozilla/social/navigation/MozillaNavHost.kt
+++ b/app/src/main/java/org/mozilla/social/navigation/MozillaNavHost.kt
@@ -1,8 +1,14 @@
 package org.mozilla.social.navigation
 
 import android.content.Context
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -10,6 +16,7 @@ import androidx.navigation.navigation
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.mozilla.social.R
+import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.SnackbarType
 import org.mozilla.social.core.navigation.NavigationDestination
 import org.mozilla.social.feature.account.accountScreen
@@ -27,9 +34,46 @@ import org.mozilla.social.post.newPostScreen
 import org.mozilla.social.search.searchScreen
 import org.mozilla.social.ui.AppState
 
+private const val SCREEN_ANIMATION_DURATION = 500
+
 @Composable
 fun MozillaNavHost(appState: AppState, context: Context) {
-    NavHost(navController = appState.navController, startDestination = Routes.SPLASH) {
+    NavHost(
+        navController = appState.navController,
+        startDestination = Routes.SPLASH,
+        enterTransition = {
+            fadeIn(
+                animationSpec = tween(SCREEN_ANIMATION_DURATION)
+            ) +
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Right
+            )
+        },
+        exitTransition = {
+            fadeOut(
+                animationSpec = tween(SCREEN_ANIMATION_DURATION)
+            ) +
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Right
+            )
+        },
+        popEnterTransition = {
+            fadeIn(
+                animationSpec = tween(SCREEN_ANIMATION_DURATION)
+            ) +
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Left
+            )
+        },
+        popExitTransition = {
+            fadeOut(
+                animationSpec = tween(SCREEN_ANIMATION_DURATION)
+            ) +
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Left
+            )
+        }
+    ) {
         splashScreen(
             navigateToLogin = appState::navigateToLoginScreen,
             navigateToLoggedInGraph = appState::navigateToLoggedInGraph,
@@ -99,6 +143,10 @@ private fun NavGraphBuilder.mainGraph(
             postCardNavigation = appState.postCardNavigation,
         )
 
-        composable(route = NavigationDestination.Bookmarks.route) { Text(text = "bookmarks") }
+        composable(route = NavigationDestination.Bookmarks.route) {
+            MoSoSurface(modifier = Modifier.fillMaxSize()) {
+                Text(text = "bookmarks")
+            }
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
+++ b/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
@@ -95,6 +95,8 @@ fun MainActivityScreen(context: Context) {
         bottomSheetContent = { BottomSheetContent() },
         bottomSheetVisible = appState.bottomSheetVisible.value,
         content = { paddingValues ->
+            // This reduces screen transition animation jank when going between a screen
+            // that shows the top / bottom bar and a screen that doesn't
             val padding = if (AppState.shouldShowTopBar(currentDestination)) {
                 paddingValues
             } else {

--- a/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
+++ b/app/src/main/java/org/mozilla/social/ui/MainActivityScreen.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -91,8 +94,13 @@ fun MainActivityScreen(context: Context) {
         },
         bottomSheetContent = { BottomSheetContent() },
         bottomSheetVisible = appState.bottomSheetVisible.value,
-        content = {
-            Box(modifier = Modifier.padding(it)) {
+        content = { paddingValues ->
+            val padding = if (AppState.shouldShowTopBar(currentDestination)) {
+                paddingValues
+            } else {
+                WindowInsets.statusBars.asPaddingValues()
+            }
+            Box(modifier = Modifier.padding(padding)) {
                 MozillaNavHost(appState = appState, context = context)
             }
         }

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoScaffold.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoScaffold.kt
@@ -40,7 +40,7 @@ fun MoSoScaffold(
             ) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.BottomCenter
+                    contentAlignment = Alignment.TopStart
                 ) {
                     content(it)
                     MosSoBottomSheet(visible = bottomSheetVisible, content = bottomSheetContent)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmode
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version = "2.6.0"}
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version = "2.7.4"}
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging" }
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "androidx-paging" }
 androidx-room = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }


### PR DESCRIPTION
- Adding screen transition animations
  - There is a small amount of animation jank due to the top and bottom app bars in the scaffold.  Is there a way we can make the scaffold only exist on the main screens and not be a hidden element on all other screens? 