### PR TITLE
Edit profile screen

### DIFF
--- a/app/src/main/java/org/mozilla/social/navigation/MozillaNavHost.kt
+++ b/app/src/main/java/org/mozilla/social/navigation/MozillaNavHost.kt
@@ -20,6 +20,7 @@ import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.SnackbarType
 import org.mozilla.social.core.navigation.NavigationDestination
 import org.mozilla.social.feature.account.accountScreen
+import org.mozilla.social.feature.account.edit.editAccountScreen
 import org.mozilla.social.feature.account.myAccountScreen
 import org.mozilla.social.feature.auth.loginScreen
 import org.mozilla.social.feature.discover.discoverScreen
@@ -116,6 +117,9 @@ private fun NavGraphBuilder.mainGraph(
         myAccountScreen(
             accountNavigationCallbacks = appState.accountNavigation,
             postCardNavigation = appState.postCardNavigation,
+        )
+        editAccountScreen(
+            onDone = { appState.popBackStack() }
         )
         followersScreen(followersNavigationCallbacks = appState.followersNavigation)
         followingScreen(followersNavigationCallbacks = appState.followersNavigation)

--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -33,6 +33,7 @@ import org.mozilla.social.core.designsystem.component.MoSoSnackbarHostState
 import org.mozilla.social.core.navigation.NavigationDestination
 import org.mozilla.social.core.ui.postcard.PostCardNavigation
 import org.mozilla.social.feature.account.AccountNavigationCallbacks
+import org.mozilla.social.feature.account.edit.navigateToEditAccount
 import org.mozilla.social.feature.account.navigateToAccount
 import org.mozilla.social.feature.auth.navigateToLoginScreen
 import org.mozilla.social.feature.followers.FollowersNavigationCallbacks
@@ -137,6 +138,7 @@ class AppState(
             accountId = accountId,
             accountHandle = accountHandle
         )
+        override fun onEditProfileClicked() = navigateToEditAccount()
     }
 
     val followersNavigation = object : FollowersNavigationCallbacks {
@@ -194,6 +196,10 @@ class AppState(
         navController.navigateToAccount(
             accountId = accountId,
         )
+    }
+
+    fun navigateToEditAccount() {
+        navController.navigateToEditAccount()
     }
 
     fun navigateToAccountFollowing(accountId: String) {

--- a/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
@@ -1,6 +1,5 @@
 package org.mozilla.social.core.data.repository
 
-import kotlinx.coroutines.coroutineScope
 import org.mozilla.social.core.data.repository.model.account.toExternal
 import org.mozilla.social.core.data.repository.model.followers.FollowersPagingWrapper
 import org.mozilla.social.core.data.repository.model.status.toExternalModel
@@ -10,7 +9,6 @@ import org.mozilla.social.model.Account
 import org.mozilla.social.model.Relationship
 import org.mozilla.social.model.Status
 import retrofit2.HttpException
-import retrofit2.Response
 
 class AccountRepository internal constructor(
     private val accountApi: AccountApi,
@@ -22,9 +20,10 @@ class AccountRepository internal constructor(
     }
 
     suspend fun getAccount(accountId: String): Account =
-        coroutineScope {
-            accountApi.getAccount(accountId).toExternalModel()
-        }
+        accountApi.getAccount(accountId).toExternalModel()
+
+    suspend fun getAccountFromDatabase(accountId: String): Account? =
+        socialDatabase.accountsDao().getAccount(accountId)?.toExternalModel()
 
     suspend fun getAccountRelationships(
         accountIds: List<String>,

--- a/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
@@ -1,5 +1,7 @@
 package org.mozilla.social.core.data.repository
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.mozilla.social.core.data.repository.model.account.toExternal
 import org.mozilla.social.core.data.repository.model.followers.FollowersPagingWrapper
 import org.mozilla.social.core.data.repository.model.status.toDatabaseModel
@@ -174,7 +176,7 @@ class AccountRepository internal constructor(
     suspend fun updateMyAccount(
         displayName: String? = null,
         bio: String? = null,
-    ) {
+    ) = withContext(Dispatchers.IO) {
         val updatedAccount = accountApi.updateAccount(
             NetworkAccountUpdate(
                 displayName = displayName,

--- a/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/repository/AccountRepository.kt
@@ -2,9 +2,11 @@ package org.mozilla.social.core.data.repository
 
 import org.mozilla.social.core.data.repository.model.account.toExternal
 import org.mozilla.social.core.data.repository.model.followers.FollowersPagingWrapper
+import org.mozilla.social.core.data.repository.model.status.toDatabaseModel
 import org.mozilla.social.core.data.repository.model.status.toExternalModel
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.network.AccountApi
+import org.mozilla.social.core.network.model.request.NetworkAccountUpdate
 import org.mozilla.social.model.Account
 import org.mozilla.social.model.Relationship
 import org.mozilla.social.model.Status
@@ -162,5 +164,18 @@ class AccountRepository internal constructor(
             socialDatabase.relationshipsDao().updateMuted(accountId, true)
             throw e
         }
+    }
+
+    suspend fun updateMyAccount(
+        displayName: String? = null,
+        bio: String? = null,
+    ) {
+        val updatedAccount = accountApi.updateAccount(
+            NetworkAccountUpdate(
+                displayName = displayName,
+                bio = bio,
+            )
+        ).toExternalModel()
+        socialDatabase.accountsDao().insert(updatedAccount.toDatabaseModel())
     }
 }

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoTopBar.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoTopBar.kt
@@ -25,6 +25,7 @@ import org.mozilla.social.core.designsystem.theme.MoSoTheme
 
 @Composable
 fun MoSoTopBar(
+    modifier: Modifier = Modifier,
     title: String = "",
     icon: Painter? = MoSoIcons.close(),
     onIconClicked: () -> Unit,
@@ -33,7 +34,7 @@ fun MoSoTopBar(
     showDivider: Boolean = true,
 ) {
     Column(
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth()
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationDestination.kt
@@ -16,6 +16,10 @@ sealed class NavigationDestination(
         fun route(accountId: String): String = "$route?$NAV_PARAM_ACCOUNT_ID=$accountId"
     }
 
+    data object EditAccount: NavigationDestination(
+        route = "editAccount"
+    )
+
     data object Auth: NavigationDestination(
         route = "auth"
     )

--- a/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
+++ b/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
@@ -3,10 +3,13 @@ package org.mozilla.social.core.network
 import org.mozilla.social.core.network.model.NetworkAccount
 import org.mozilla.social.core.network.model.NetworkRelationship
 import org.mozilla.social.core.network.model.NetworkStatus
+import org.mozilla.social.core.network.model.request.NetworkAccountUpdate
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -107,4 +110,9 @@ interface AccountApi {
     suspend fun getRelationships(
         @Query("id") ids: Array<String>
     ): List<NetworkRelationship>
+
+    @PATCH("/api/v1/accounts/update_credentials")
+    suspend fun updateAccount(
+        @Body updateBody: NetworkAccountUpdate,
+    ): NetworkAccount
 }

--- a/core/network/src/main/java/org/mozilla/social/core/network/model/request/NetworkAccountUpdate.kt
+++ b/core/network/src/main/java/org/mozilla/social/core/network/model/request/NetworkAccountUpdate.kt
@@ -1,0 +1,12 @@
+package org.mozilla.social.core.network.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NetworkAccountUpdate(
+    @SerialName("display_name")
+    val displayName: String? = null,
+    @SerialName("note")
+    val bio: String? = null,
+)

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountInteractions.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountInteractions.kt
@@ -7,4 +7,5 @@ interface AccountInteractions : OverflowInteractions {
     fun onUnfollowClicked() = Unit
     fun onRetryClicked() = Unit
     fun onTabClicked(timelineType: TimelineType) = Unit
+    fun onEditAccountClicked() = Unit
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountModule.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountModule.kt
@@ -2,6 +2,7 @@ package org.mozilla.social.feature.account
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.feature.account.edit.EditAccountViewModel
 
 val accountModule = module {
     viewModel { parametersHolder ->
@@ -25,6 +26,12 @@ val accountModule = module {
             get(),
             parametersHolder[0],
             parametersHolder[1],
+        )
+    }
+    viewModel {
+        EditAccountViewModel(
+            get(),
+            get(),
         )
     }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountNavigationCallbacks.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountNavigationCallbacks.kt
@@ -8,4 +8,5 @@ interface AccountNavigationCallbacks {
         accountId: String,
         accountHandle: String,
     ) = Unit
+    fun onEditProfileClicked() = Unit
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -11,10 +11,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -26,13 +23,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,12 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -57,7 +46,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.paging.PagingData
-import coil.compose.AsyncImage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -70,7 +58,6 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.designsystem.component.MoSoButton
 import org.mozilla.social.core.designsystem.component.MoSoButtonSecondary
 import org.mozilla.social.core.designsystem.component.MoSoCircularProgressIndicator
-import org.mozilla.social.core.designsystem.component.MoSoDivider
 import org.mozilla.social.core.designsystem.component.MoSoDropdownMenu
 import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.MoSoTab
@@ -88,7 +75,6 @@ import org.mozilla.social.core.ui.postcard.PostCardInteractions
 import org.mozilla.social.core.ui.postcard.PostCardList
 import org.mozilla.social.core.ui.postcard.PostCardNavigation
 import org.mozilla.social.core.ui.postcard.PostCardUiState
-import kotlin.math.max
 
 @Composable
 internal fun AccountScreen(
@@ -116,7 +102,7 @@ internal fun AccountScreen(
         accountNavigationCallbacks = accountNavigationCallbacks,
         htmlContentInteractions = viewModel.postCardDelegate,
         postCardInteractions = viewModel.postCardDelegate,
-        accountInteractions = viewModel
+        accountInteractions = viewModel,
     )
 
     LaunchedEffect(Unit) {
@@ -247,10 +233,38 @@ private fun MainContent(
             postCardInteractions = postCardInteractions
         ) {
             Header(
-                isUsersProfile = isUsersProfile,
-                accountUiState = account,
-                accountInteractions = accountInteractions,
-            )
+                headerUrl = account.headerUrl,
+                avatarUrl = account.avatarUrl,
+            ) {
+                val buttonModifier = Modifier.padding(end = 8.dp)
+                if (isUsersProfile) {
+                    MoSoButtonSecondary(
+                        modifier = buttonModifier,
+                        onClick = { accountInteractions.onEditAccountClicked() }
+                    ) {
+                        Text(text = stringResource(id = R.string.edit_button))
+                    }
+                } else {
+                    MoSoButton(
+                        modifier = buttonModifier,
+                        onClick = {
+                            if (account.isFollowing) {
+                                accountInteractions.onUnfollowClicked()
+                            } else {
+                                accountInteractions.onFollowClicked()
+                            }
+                        }
+                    ) {
+                        Text(
+                            text = if (account.isFollowing) {
+                                stringResource(id = R.string.unfollow_button)
+                            } else {
+                                stringResource(id = R.string.follow_button)
+                            }
+                        )
+                    }
+                }
+            }
 
             UserInfo(account = account)
             Spacer(modifier = Modifier.height(12.dp))
@@ -580,123 +594,6 @@ private fun UserLabel(
             linkColor = MoSoTheme.colors.textSecondary,
             maximumLineCount = 1,
         )
-    }
-}
-
-@Composable
-private fun Header(
-    modifier: Modifier = Modifier,
-    isUsersProfile: Boolean,
-    accountUiState: AccountUiState,
-    accountInteractions: AccountInteractions,
-) {
-    HeaderLayout(
-        modifier = modifier.fillMaxWidth(),
-        headerImage = {
-            AsyncImage(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(120.dp),
-                model = accountUiState.headerUrl,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-            )
-        },
-        profileImage = {
-            AsyncImage(
-                modifier = Modifier
-                    .padding(start = 8.dp)
-                    .size(92.dp)
-                    .clip(CircleShape)
-                    .border(
-                        width = 3.dp,
-                        color = MoSoTheme.colors.layer1,
-                        shape = CircleShape
-                    ),
-                model = accountUiState.avatarUrl,
-                contentDescription = null,
-            )
-        },
-        rightSideContent = {
-            val buttonModifier = Modifier.padding(end = 8.dp)
-            if (isUsersProfile) {
-                MoSoButtonSecondary(
-                    modifier = buttonModifier,
-                    onClick = { /*TODO*/ }
-                ) {
-                    Text(text = stringResource(id = R.string.edit_button))
-                }
-            } else {
-                MoSoButton(
-                    modifier = buttonModifier,
-                    onClick = {
-                        if (accountUiState.isFollowing) {
-                            accountInteractions.onUnfollowClicked()
-                        } else {
-                            accountInteractions.onFollowClicked()
-                        }
-                    }
-                ) {
-                    Text(
-                        text = if (accountUiState.isFollowing) {
-                            stringResource(id = R.string.unfollow_button)
-                        } else {
-                            stringResource(id = R.string.follow_button)
-                        }
-                    )
-                }
-            }
-        }
-    )
-}
-
-/**
- * Layout for the header images and edit / follow buttons
- * Using a layout is nice because it automatically calculates the spacing for the
- * avatar image so you don't have to calculate the value yourself if the avatar size changes.
- */
-@Composable
-private fun HeaderLayout(
-    modifier: Modifier = Modifier,
-    headerImage: @Composable () -> Unit,
-    profileImage: @Composable () -> Unit,
-    rightSideContent: @Composable () -> Unit,
-) {
-    Layout(
-        modifier = modifier,
-        content = {
-            Box { headerImage() }
-            Box { profileImage() }
-            Box { rightSideContent() }
-        },
-    ) { measurables, constraints ->
-        val placeables = measurables.map {
-            it.measure(constraints.copy(
-                minWidth = 0,
-                minHeight = 0,
-            ))
-        }
-        val headerImagePlaceable = placeables[0]
-        val profileImagePlaceable = placeables[1]
-        val rightSideContentPlaceable = placeables[2]
-        layout(
-            width = constraints.maxWidth,
-            height = headerImagePlaceable.height
-                    + max(profileImagePlaceable.height / 2, rightSideContentPlaceable.height),
-        ) {
-            headerImagePlaceable.placeRelative(
-                x = 0,
-                y = 0,
-            )
-            profileImagePlaceable.placeRelative(
-                x = 0,
-                y = headerImagePlaceable.height - profileImagePlaceable.height / 2
-            )
-            rightSideContentPlaceable.placeRelative(
-                x = (constraints.maxWidth - rightSideContentPlaceable.width),
-                y = headerImagePlaceable.height
-            )
-        }
     }
 }
 

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -235,6 +235,8 @@ private fun MainContent(
             Header(
                 headerUrl = account.headerUrl,
                 avatarUrl = account.avatarUrl,
+                displayName = account.displayName,
+                handle = "@${account.webFinger}",
             ) {
                 val buttonModifier = Modifier.padding(end = 8.dp)
                 if (isUsersProfile) {
@@ -266,7 +268,6 @@ private fun MainContent(
                 }
             }
 
-            UserInfo(account = account)
             Spacer(modifier = Modifier.height(12.dp))
             UserBio(
                 account = account,

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -408,27 +408,6 @@ private fun OverflowMenu(
 }
 
 @Composable
-private fun UserInfo(
-    account: AccountUiState,
-) {
-    Column(
-        modifier = Modifier
-            .padding(start = 8.dp, top = 8.dp)
-            .fillMaxWidth()
-    ) {
-        Text(
-            text = account.displayName,
-            style = MoSoTheme.typography.titleLarge
-        )
-        Text(
-            text = "@${account.webFinger}",
-            style = MoSoTheme.typography.labelMedium,
-            color = MoSoTheme.colors.textSecondary,
-        )
-    }
-}
-
-@Composable
 private fun UserFollow(
     account: AccountUiState,
     accountInteractions: AccountInteractions,

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountUi.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountUi.kt
@@ -1,12 +1,15 @@
 package org.mozilla.social.feature.account
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,37 +25,67 @@ internal fun Header(
     modifier: Modifier = Modifier,
     headerUrl: String,
     avatarUrl: String,
+    displayName: String,
+    handle: String,
     rightSideContent: @Composable () -> Unit,
 ) {
-    HeaderLayout(
-        modifier = modifier.fillMaxWidth(),
-        headerImage = {
-            AsyncImage(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(120.dp),
-                model = headerUrl,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-            )
-        },
-        profileImage = {
-            AsyncImage(
-                modifier = Modifier
-                    .padding(start = 8.dp)
-                    .size(92.dp)
-                    .clip(CircleShape)
-                    .border(
-                        width = 3.dp,
-                        color = MoSoTheme.colors.layer1,
-                        shape = CircleShape
-                    ),
-                model = avatarUrl,
-                contentDescription = null,
-            )
-        },
-        rightSideContent = rightSideContent,
-    )
+    Column {
+        HeaderLayout(
+            modifier = modifier.fillMaxWidth(),
+            headerImage = {
+                AsyncImage(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(120.dp)
+                        .background(MoSoTheme.colors.layer2),
+                    model = headerUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                )
+            },
+            profileImage = {
+                AsyncImage(
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .size(92.dp)
+                        .clip(CircleShape)
+                        .border(
+                            width = 3.dp,
+                            color = MoSoTheme.colors.layer1,
+                            shape = CircleShape
+                        )
+                        .background(MoSoTheme.colors.layer2),
+                    model = avatarUrl,
+                    contentDescription = null,
+                )
+            },
+            rightSideContent = rightSideContent,
+        )
+
+        UserInfo(displayName = displayName, handle = handle)
+    }
+}
+
+@Composable
+private fun UserInfo(
+    displayName: String,
+    handle: String,
+) {
+    Column(
+        modifier = Modifier
+            .padding(start = 8.dp, top = 8.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = displayName,
+            style = MoSoTheme.typography.titleLarge
+        )
+        Text(
+            text = handle,
+            style = MoSoTheme.typography.labelMedium,
+            color = MoSoTheme.colors.textSecondary,
+        )
+    }
 }
 
 /**

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountUi.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountUi.kt
@@ -1,0 +1,106 @@
+package org.mozilla.social.feature.account
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import kotlin.math.max
+
+@Composable
+internal fun Header(
+    modifier: Modifier = Modifier,
+    headerUrl: String,
+    avatarUrl: String,
+    rightSideContent: @Composable () -> Unit,
+) {
+    HeaderLayout(
+        modifier = modifier.fillMaxWidth(),
+        headerImage = {
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+                model = headerUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+            )
+        },
+        profileImage = {
+            AsyncImage(
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .size(92.dp)
+                    .clip(CircleShape)
+                    .border(
+                        width = 3.dp,
+                        color = MoSoTheme.colors.layer1,
+                        shape = CircleShape
+                    ),
+                model = avatarUrl,
+                contentDescription = null,
+            )
+        },
+        rightSideContent = rightSideContent,
+    )
+}
+
+/**
+ * Layout for the header images and edit / follow buttons
+ * Using a layout is nice because it automatically calculates the spacing for the
+ * avatar image so you don't have to calculate the value yourself if the avatar size changes.
+ */
+@Composable
+private fun HeaderLayout(
+    modifier: Modifier = Modifier,
+    headerImage: @Composable () -> Unit,
+    profileImage: @Composable () -> Unit,
+    rightSideContent: @Composable () -> Unit,
+) {
+    Layout(
+        modifier = modifier,
+        content = {
+            Box { headerImage() }
+            Box { profileImage() }
+            Box { rightSideContent() }
+        },
+    ) { measurables, constraints ->
+        val placeables = measurables.map {
+            it.measure(constraints.copy(
+                minWidth = 0,
+                minHeight = 0,
+            ))
+        }
+        val headerImagePlaceable = placeables[0]
+        val profileImagePlaceable = placeables[1]
+        val rightSideContentPlaceable = placeables[2]
+        layout(
+            width = constraints.maxWidth,
+            height = headerImagePlaceable.height
+                    + max(profileImagePlaceable.height / 2, rightSideContentPlaceable.height),
+        ) {
+            headerImagePlaceable.placeRelative(
+                x = 0,
+                y = 0,
+            )
+            profileImagePlaceable.placeRelative(
+                x = 0,
+                y = headerImagePlaceable.height - profileImagePlaceable.height / 2
+            )
+            rightSideContentPlaceable.placeRelative(
+                x = (constraints.maxWidth - rightSideContentPlaceable.width),
+                y = headerImagePlaceable.height
+            )
+        }
+    }
+}

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
@@ -222,4 +222,8 @@ class AccountViewModel(
     override fun onTabClicked(timelineType: TimelineType) {
         _timelineType.edit { timelineType }
     }
+
+    override fun onEditAccountClicked() {
+        accountNavigationCallbacks.onEditProfileClicked()
+    }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountInteractions.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountInteractions.kt
@@ -1,0 +1,8 @@
+package org.mozilla.social.feature.account.edit
+
+import org.mozilla.social.feature.account.AccountUiState
+
+interface EditAccountInteractions {
+    fun onDisplayNameTextChanged(text: String) = Unit
+    fun onBioTextChanged(text: String) = Unit
+}

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountInteractions.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountInteractions.kt
@@ -5,4 +5,5 @@ import org.mozilla.social.feature.account.AccountUiState
 interface EditAccountInteractions {
     fun onDisplayNameTextChanged(text: String) = Unit
     fun onBioTextChanged(text: String) = Unit
+    fun onSaveClicked() = Unit
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountNavigation.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountNavigation.kt
@@ -1,0 +1,23 @@
+package org.mozilla.social.feature.account.edit
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import org.mozilla.social.core.navigation.NavigationDestination
+
+fun NavController.navigateToEditAccount(
+    navOptions: NavOptions? = null,
+) {
+    navigate(NavigationDestination.EditAccount.route, navOptions)
+}
+
+fun NavGraphBuilder.editAccountScreen(
+    onDone: () -> Unit,
+) {
+    composable(
+        route = NavigationDestination.EditAccount.route,
+    ) {
+        EditAccountScreen(onDone = onDone)
+    }
+}

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
@@ -1,11 +1,15 @@
 package org.mozilla.social.feature.account.edit
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -50,18 +54,25 @@ fun EditAccountScreen(
     editAccountUiState: Resource<EditAccountUiState>,
 ) {
     MoSoSurface(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize(),
     ) {
-        when (editAccountUiState) {
-            is Resource.Loading -> {}
-            is Resource.Loaded -> {
-                LoadedState(
-                    onCloseClicked = onCloseClicked,
-                    editAccountInteractions = editAccountInteractions,
-                    uiState = editAccountUiState.data,
-                )
+        Box(
+            modifier = Modifier
+                .windowInsetsPadding(WindowInsets.systemBars),
+        ) {
+            when (editAccountUiState) {
+                is Resource.Loading -> {}
+                is Resource.Loaded -> {
+                    LoadedState(
+                        onCloseClicked = onCloseClicked,
+                        editAccountInteractions = editAccountInteractions,
+                        uiState = editAccountUiState.data,
+                    )
+                }
+
+                is Resource.Error -> {}
             }
-            is Resource.Error -> {}
         }
     }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
@@ -1,0 +1,104 @@
+package org.mozilla.social.feature.account.edit
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+import org.mozilla.social.common.Resource
+import org.mozilla.social.core.designsystem.component.MoSoSurface
+import org.mozilla.social.core.designsystem.component.MoSoTextField
+import org.mozilla.social.core.designsystem.component.MoSoTopBar
+import org.mozilla.social.feature.account.Header
+import org.mozilla.social.feature.account.R
+
+@Composable
+internal fun EditAccountScreen(
+    onDone: () -> Unit,
+    viewModel: EditAccountViewModel = koinViewModel(
+        parameters = {
+            parametersOf(
+                onDone,
+            )
+        }
+    ),
+) {
+    EditAccountScreen(
+        onCloseClicked = onDone,
+        editAccountInteractions = viewModel,
+        editAccountUiState = viewModel.editAccountUiState.collectAsState().value,
+    )
+}
+
+@Composable
+fun EditAccountScreen(
+    onCloseClicked: () -> Unit,
+    editAccountInteractions: EditAccountInteractions,
+    editAccountUiState: Resource<EditAccountUiState>,
+) {
+    MoSoSurface(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        when (editAccountUiState) {
+            is Resource.Loading -> {}
+            is Resource.Loaded -> {
+                LoadedState(
+                    onCloseClicked = onCloseClicked,
+                    editAccountInteractions = editAccountInteractions,
+                    editAccountUiState = editAccountUiState.data,
+                )
+            }
+            is Resource.Error -> {}
+        }
+    }
+}
+
+@Composable
+private fun LoadedState(
+    onCloseClicked: () -> Unit,
+    editAccountInteractions: EditAccountInteractions,
+    editAccountUiState: EditAccountUiState,
+) {
+    Column {
+        MoSoTopBar(onIconClicked = { onCloseClicked() })
+        Header(
+            headerUrl = editAccountUiState.headerUrl,
+            avatarUrl = editAccountUiState.avatarUrl
+        ) {
+            //TODO bot and lock
+        }
+        MoSoTextField(
+            modifier = Modifier
+                .fillMaxWidth(),
+            value = editAccountUiState.displayName,
+            onValueChange = editAccountInteractions::onDisplayNameTextChanged,
+            label = {
+                Text(text = stringResource(id = R.string.edit_account_display_name_label))
+            }
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        MoSoTextField(
+            modifier = Modifier
+                .fillMaxWidth(),
+            value = editAccountUiState.bio,
+            onValueChange = editAccountInteractions::onBioTextChanged,
+            label = {
+                Text(text = stringResource(id = R.string.edit_account_bio_label))
+            }
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(text = "${editAccountUiState.bioCharacterCount}/500")
+    }
+}

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
@@ -1,5 +1,7 @@
 package org.mozilla.social.feature.account.edit
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -7,9 +9,12 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -59,7 +64,8 @@ fun EditAccountScreen(
     ) {
         Box(
             modifier = Modifier
-                .windowInsetsPadding(WindowInsets.systemBars),
+                .systemBarsPadding()
+                .imePadding(),
         ) {
             when (editAccountUiState) {
                 is Resource.Loading -> {}
@@ -108,34 +114,34 @@ private fun LoadedState(
             //TODO bot and lock
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Column(
-            modifier = Modifier.padding(horizontal = 8.dp)
-        ) {
-            MoSoTextField(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                value = uiState.displayName,
-                onValueChange = editAccountInteractions::onDisplayNameTextChanged,
-                label = {
-                    Text(text = stringResource(id = R.string.edit_account_display_name_label))
-                }
-            )
-
             Spacer(modifier = Modifier.height(16.dp))
 
-            MoSoTextField(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                value = uiState.bio,
-                onValueChange = editAccountInteractions::onBioTextChanged,
-                label = {
-                    Text(text = stringResource(id = R.string.edit_account_bio_label))
-                }
-            )
+            Column(
+                modifier = Modifier.padding(horizontal = 8.dp)
+            ) {
+                MoSoTextField(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    value = uiState.displayName,
+                    onValueChange = editAccountInteractions::onDisplayNameTextChanged,
+                    label = {
+                        Text(text = stringResource(id = R.string.edit_account_display_name_label))
+                    }
+                )
 
-            Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(16.dp))
+
+                MoSoTextField(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    value = uiState.bio,
+                    onValueChange = editAccountInteractions::onBioTextChanged,
+                    label = {
+                        Text(text = stringResource(id = R.string.edit_account_bio_label))
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
 
             Text(
                 modifier = Modifier.align(Alignment.End),

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
@@ -5,18 +5,23 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.common.Resource
+import org.mozilla.social.core.designsystem.component.MoSoButton
 import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.MoSoTextField
 import org.mozilla.social.core.designsystem.component.MoSoTopBar
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.feature.account.Header
 import org.mozilla.social.feature.account.R
 
@@ -53,7 +58,7 @@ fun EditAccountScreen(
                 LoadedState(
                     onCloseClicked = onCloseClicked,
                     editAccountInteractions = editAccountInteractions,
-                    editAccountUiState = editAccountUiState.data,
+                    uiState = editAccountUiState.data,
                 )
             }
             is Resource.Error -> {}
@@ -65,40 +70,90 @@ fun EditAccountScreen(
 private fun LoadedState(
     onCloseClicked: () -> Unit,
     editAccountInteractions: EditAccountInteractions,
-    editAccountUiState: EditAccountUiState,
+    uiState: EditAccountUiState,
 ) {
     Column {
-        MoSoTopBar(onIconClicked = { onCloseClicked() })
+        MoSoTopBar(
+            onIconClicked = { onCloseClicked() },
+            title = uiState.topBarTitle,
+            rightSideContent = {
+                MoSoButton(
+                    modifier = Modifier
+                        .padding(8.dp)
+                        .height(38.dp),
+                    onClick = { editAccountInteractions.onSaveClicked() }
+                ) {
+                    Text(text = stringResource(id = R.string.edit_account_save_button))
+                }
+            },
+            showDivider = false,
+        )
         Header(
-            headerUrl = editAccountUiState.headerUrl,
-            avatarUrl = editAccountUiState.avatarUrl
+            headerUrl = uiState.headerUrl,
+            avatarUrl = uiState.avatarUrl,
+            displayName = uiState.topBarTitle,
+            handle = uiState.handle,
         ) {
             //TODO bot and lock
         }
-        MoSoTextField(
-            modifier = Modifier
-                .fillMaxWidth(),
-            value = editAccountUiState.displayName,
-            onValueChange = editAccountInteractions::onDisplayNameTextChanged,
-            label = {
-                Text(text = stringResource(id = R.string.edit_account_display_name_label))
-            }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Column(
+            modifier = Modifier.padding(horizontal = 8.dp)
+        ) {
+            MoSoTextField(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                value = uiState.displayName,
+                onValueChange = editAccountInteractions::onDisplayNameTextChanged,
+                label = {
+                    Text(text = stringResource(id = R.string.edit_account_display_name_label))
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            MoSoTextField(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                value = uiState.bio,
+                onValueChange = editAccountInteractions::onBioTextChanged,
+                label = {
+                    Text(text = stringResource(id = R.string.edit_account_bio_label))
+                }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                modifier = Modifier.align(Alignment.End),
+                text = "${uiState.bioCharacterCount}/500",
+                style = MoSoTheme.typography.labelSmall,
+                color = MoSoTheme.colors.textSecondary,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewEditAccountScreen() {
+    MoSoTheme {
+        EditAccountScreen(
+            onCloseClicked = { },
+            editAccountUiState = Resource.Loaded(
+                data = EditAccountUiState(
+                    topBarTitle = "John",
+                    headerUrl = "",
+                    avatarUrl = "",
+                    handle = "@john",
+                    displayName = "John New",
+                    bio = "I'm super cool",
+                    bioCharacterCount = 20,
+                )
+            ),
+            editAccountInteractions = object : EditAccountInteractions {}
         )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        MoSoTextField(
-            modifier = Modifier
-                .fillMaxWidth(),
-            value = editAccountUiState.bio,
-            onValueChange = editAccountInteractions::onBioTextChanged,
-            label = {
-                Text(text = stringResource(id = R.string.edit_account_bio_label))
-            }
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(text = "${editAccountUiState.bioCharacterCount}/500")
     }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountUiState.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountUiState.kt
@@ -1,7 +1,7 @@
 package org.mozilla.social.feature.account.edit
 
 data class EditAccountUiState(
-    val userName: String,
+    val topBarTitle: String,
     val headerUrl: String,
     val avatarUrl: String,
     val handle: String,

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountUiState.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountUiState.kt
@@ -1,0 +1,12 @@
+package org.mozilla.social.feature.account.edit
+
+data class EditAccountUiState(
+    val userName: String,
+    val headerUrl: String,
+    val avatarUrl: String,
+    val handle: String,
+    val displayName: String = "",
+    val bio: String = "",
+    val bioCharacterCount: Int = 0,
+)
+

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountViewModel.kt
@@ -34,10 +34,10 @@ class EditAccountViewModel(
                 _editAccountUiState.update {
                     Resource.Loaded(
                         data = EditAccountUiState(
-                            userName = account.displayName,
+                            topBarTitle = account.displayName,
                             headerUrl = account.headerUrl,
                             avatarUrl = account.avatarUrl,
-                            handle = account.acct,
+                            handle = "@${account.acct}",
                             displayName = account.displayName,
                             bio = bio,
                             bioCharacterCount = bio.length,
@@ -73,6 +73,12 @@ class EditAccountViewModel(
                     )
                 )
             }
+        }
+    }
+
+    override fun onSaveClicked() {
+        viewModelScope.launch {
+
         }
     }
 

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountViewModel.kt
@@ -1,0 +1,82 @@
+package org.mozilla.social.feature.account.edit
+
+import androidx.core.text.HtmlCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.mozilla.social.common.Resource
+import org.mozilla.social.core.data.repository.AccountRepository
+import org.mozilla.social.core.domain.AccountIdBlocking
+import timber.log.Timber
+
+class EditAccountViewModel(
+    private val accountRepository: AccountRepository,
+    accountIdBlocking: AccountIdBlocking,
+) : ViewModel(), EditAccountInteractions {
+
+    private val accountId = accountIdBlocking()
+
+    private val _editAccountUiState = MutableStateFlow<Resource<EditAccountUiState>>(Resource.Loading())
+    val editAccountUiState = _editAccountUiState.asStateFlow()
+
+    init {
+        loadAccount()
+    }
+
+    private fun loadAccount() {
+        viewModelScope.launch {
+            try {
+                val account = accountRepository.getAccountFromDatabase(accountId)!!
+                val bio = HtmlCompat.fromHtml(account.bio, 0).toString()
+                _editAccountUiState.update {
+                    Resource.Loaded(
+                        data = EditAccountUiState(
+                            userName = account.displayName,
+                            headerUrl = account.headerUrl,
+                            avatarUrl = account.avatarUrl,
+                            handle = account.acct,
+                            displayName = account.displayName,
+                            bio = bio,
+                            bioCharacterCount = bio.length,
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+        }
+    }
+
+    override fun onDisplayNameTextChanged(text: String) {
+        with(_editAccountUiState.value as? Resource.Loaded ?: return) {
+            _editAccountUiState.update {
+                Resource.Loaded(
+                    data = data.copy(
+                        displayName = text
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onBioTextChanged(text: String) {
+        if (text.length > MAX_BIO_LENGTH) return
+        with(_editAccountUiState.value as? Resource.Loaded ?: return) {
+            _editAccountUiState.update {
+                Resource.Loaded(
+                    data = data.copy(
+                        bio = text,
+                        bioCharacterCount = text.length
+                    )
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val MAX_BIO_LENGTH = 500
+    }
+}

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountViewModel.kt
@@ -77,8 +77,18 @@ class EditAccountViewModel(
     }
 
     override fun onSaveClicked() {
-        viewModelScope.launch {
-
+        with(_editAccountUiState.value as? Resource.Loaded ?: return) {
+            viewModelScope.launch {
+                try {
+                    accountRepository.updateMyAccount(
+                        displayName = data.displayName,
+                        bio = data.bio
+                    )
+                } catch (e: Exception) {
+                    //TODO show toast
+                    Timber.e(e)
+                }
+            }
         }
     }
 

--- a/feature/account/src/main/res/values/strings.xml
+++ b/feature/account/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
 
     <string name="edit_account_display_name_label">Display Name</string>
     <string name="edit_account_bio_label">Bio</string>
+    <string name="edit_account_save_button">Save</string>
 </resources>

--- a/feature/account/src/main/res/values/strings.xml
+++ b/feature/account/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="tab_media">Media</string>
 
     <string name="joined_date">Joined %s</string>
+
+    <string name="edit_account_display_name_label">Display Name</string>
+    <string name="edit_account_bio_label">Bio</string>
 </resources>


### PR DESCRIPTION
The screen is not complete yet.  This is just the first PR to get it in the app.
- Adding edit profile screen
- Can edit display name and bio (saving works but there is more to be done with load / error states, etc)
- Make the header of the account screen reusable (for use in the edit screen)