### PR TITLE
Small fixes

### DIFF
--- a/app/src/main/java/org/mozilla/social/navigation/MainNavHost.kt
+++ b/app/src/main/java/org/mozilla/social/navigation/MainNavHost.kt
@@ -1,8 +1,10 @@
 package org.mozilla.social.navigation
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -16,6 +18,7 @@ import androidx.navigation.compose.rememberNavController
 import org.mozilla.social.R
 import org.mozilla.social.common.utils.mosoFadeIn
 import org.mozilla.social.common.utils.mosoFadeOut
+import org.mozilla.social.core.designsystem.component.MoSoDivider
 import org.mozilla.social.core.designsystem.component.MoSoFloatingActionButton
 import org.mozilla.social.core.designsystem.component.MoSoSnackbar
 import org.mozilla.social.core.designsystem.component.MoSoSnackbarHost
@@ -76,7 +79,7 @@ fun NavGraphBuilder.bottomTabScreen(appState: AppState) {
         route = NavigationDestination.Tabs.route,
     ) {
         appState.tabbedNavController = rememberNavController()
-        val currentDestination = appState.currentNavigationDestination.collectAsState().value
+        val currentDestination = appState.currentNavigationDestination.collectAsState().value!!
 
         Scaffold(
             modifier = Modifier,
@@ -127,17 +130,11 @@ fun NavController.navigateToTabs(navOptions: NavOptions? = null) {
 
 @Composable
 private fun BottomBar(
-    currentDestination: NavigationDestination?,
+    currentDestination: NavigationDestination,
     navigateToTopLevelDestination: (route: NavigationDestination) -> Unit,
 ) {
-    // don't show bottom bar if our current route is not one of the bottom nav options
-    if (BottomBarTabs.values()
-            .find { it.bottomBarTab.navigationDestination == currentDestination } == null
-    ) {
-        return
-    }
-
-    currentDestination?.let {
+    Column {
+        MoSoDivider()
         MoSoBottomNavigationBar(
             currentDestination = currentDestination,
             bottomBarTabs = BottomBarTabs.values().map { it.bottomBarTab },

--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -88,10 +88,7 @@ class AppState(
         }
 
     init {
-        this.tabbedNavController = tabbedNavController
-
         coroutineScope.launch(Dispatchers.Main) {
-
             navigationEventFlow().collectLatest {
                 Timber.d("consuming event $it")
                 when (it) {

--- a/core/common/src/main/java/org/mozilla/social/common/utils/AnimationUtils.kt
+++ b/core/common/src/main/java/org/mozilla/social/common/utils/AnimationUtils.kt
@@ -26,5 +26,4 @@ fun mosoFadeIn(): EnterTransition =
 fun mosoFadeOut(): ExitTransition =
     fadeOut(tween(durationMillis = TWEEN_DURATION))
 
-const val TWEEN_DURATION = 100
-const val FADE_IN_TWEEN_DELAY = 500
+const val TWEEN_DURATION = 250

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoSwitch.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/MoSoSwitch.kt
@@ -13,9 +13,9 @@ import org.mozilla.social.core.designsystem.theme.MoSoTheme
 
 @Composable
 fun MoSoSwitch(
+    modifier: Modifier = Modifier,
     checked: Boolean = false,
     onCheckChanged: () -> Unit,
-    modifier: Modifier = Modifier,
     thumbContent: (@Composable () -> Unit)? = null,
     enabled: Boolean = true,
     colors: SwitchColors = MoSoSwitchPrimaryDefaults.colors(),

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/icon/MoSoIcons.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/icon/MoSoIcons.kt
@@ -3,6 +3,7 @@ package org.mozilla.social.core.designsystem.icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AddCircleOutline
 import androidx.compose.material.icons.rounded.AddPhotoAlternate
+import androidx.compose.material.icons.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.BookmarkBorder
 import androidx.compose.material.icons.rounded.Check
@@ -105,6 +106,9 @@ object MoSoIcons {
     // Material- avoid using these, and instead use the drawable based resources
     @Composable
     fun check() = rememberVectorPainter(image = Icons.Rounded.Check)
+
+    @Composable
+    fun backArrow() = rememberVectorPainter(image = Icons.Rounded.ArrowBack)
 
     @Composable
     fun info() = rememberVectorPainter(image = Icons.Rounded.Info)

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/EventRelay.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/EventRelay.kt
@@ -6,7 +6,7 @@ import org.mozilla.social.common.utils.StringFactory
 import timber.log.Timber
 
 class EventRelay {
-    private val _navigationEvents = MutableSharedFlow<Event>(replay = 1)
+    private val _navigationEvents = MutableSharedFlow<Event>(extraBufferCapacity = 1)
     val navigationEvents: SharedFlow<Event>
         get() = _navigationEvents
 

--- a/core/ui/src/main/java/org/mozilla/social/core/ui/appbar/MoSoTopBar.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/appbar/MoSoTopBar.kt
@@ -47,7 +47,7 @@ fun MoSoCloseableTopAppBar(
 ) {
     MoSoTopBar(
         title = title,
-        icon = if (showCloseButton) MoSoIcons.x() else null,
+        icon = if (showCloseButton) MoSoIcons.backArrow() else null,
         onIconClicked = { popBackstack() },
         actions = actions,
         showDivider = showDivider
@@ -104,7 +104,7 @@ fun MoSoTopBar(
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
-    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(),
+    colors: TopAppBarColors = MoSoTopBarDefaults.colors(),
     scrollBehavior: TopAppBarScrollBehavior? = null
 ) {
     TopAppBar(
@@ -130,7 +130,18 @@ private fun TopBarIconButton(painter: Painter, onIconClicked: () -> Unit) {
             tint = MoSoTheme.colors.iconPrimary,
         )
     }
+}
 
+object MoSoTopBarDefaults {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun colors(): TopAppBarColors = TopAppBarDefaults.topAppBarColors(
+        containerColor = MoSoTheme.colors.layer1,
+        scrolledContainerColor = MoSoTheme.colors.layer1,
+        navigationIconContentColor = MoSoTheme.colors.iconPrimary,
+        titleContentColor = MoSoTheme.colors.textPrimary,
+        actionIconContentColor = MoSoTheme.colors.iconPrimary,
+    )
 }
 
 @Preview

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -18,9 +18,11 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
@@ -117,7 +119,10 @@ private fun AccountScreen(
     accountInteractions: AccountInteractions,
 ) {
     MoSoSurface {
-        Column(Modifier.windowInsetsPadding(WindowInsets.systemBars)) {
+        Column(
+            modifier = Modifier
+                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+        ) {
             when (resource) {
                 is Resource.Loading -> {
                     MoSoCloseableTopAppBar(showCloseButton = closeButtonVisible)

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -18,11 +18,9 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
@@ -43,7 +41,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -52,7 +49,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.paging.PagingData
-import coil.compose.AsyncImage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -84,6 +80,7 @@ import org.mozilla.social.core.ui.postcard.PostCardUiState
 
 @Composable
 internal fun AccountScreen(
+    windowInsets: WindowInsets = WindowInsets.systemBars,
     accountId: String?,
     viewModel: AccountViewModel = koinViewModel(parameters = { parametersOf(accountId) }),
 ) {
@@ -97,6 +94,7 @@ internal fun AccountScreen(
         htmlContentInteractions = viewModel.postCardDelegate,
         postCardInteractions = viewModel.postCardDelegate,
         accountInteractions = viewModel,
+        windowInsets = windowInsets,
     )
 
     LaunchedEffect(Unit) {
@@ -117,11 +115,12 @@ private fun AccountScreen(
     htmlContentInteractions: HtmlContentInteractions,
     postCardInteractions: PostCardInteractions,
     accountInteractions: AccountInteractions,
+    windowInsets: WindowInsets,
 ) {
     MoSoSurface {
         Column(
             modifier = Modifier
-                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+                .windowInsetsPadding(windowInsets)
         ) {
             when (resource) {
                 is Resource.Loading -> {

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/MyAccountNavigation.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/MyAccountNavigation.kt
@@ -1,5 +1,9 @@
 package org.mozilla.social.feature.account
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -19,6 +23,7 @@ fun NavGraphBuilder.myAccountScreen(
     ) {
         AccountScreen(
             accountId = null,
+            windowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Top),
         )
     }
 }

--- a/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverScreen.kt
@@ -3,13 +3,19 @@ package org.mozilla.social.feature.discover
 
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -61,27 +67,34 @@ private fun DiscoverScreen(
     discoverInteractions: DiscoverInteractions,
 ) {
     MoSoSurface(
-        modifier = Modifier.fillMaxSize().systemBarsPadding()
+        modifier = Modifier
+            .fillMaxSize()
     ) {
-        when (recommendations) {
-            is Resource.Loaded -> {
-                MainContent(
-                    recommendations = recommendations.data,
-                    discoverInteractions = discoverInteractions,
-                )
-            }
-            is Resource.Loading -> {
-                MaxSizeLoading()
-            }
-            is Resource.Error -> {
-                GenericError(
-                    onRetryClicked = {
-                        discoverInteractions.onRetryClicked()
-                    }
-                )
+        Box(modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+        ) {
+            when (recommendations) {
+                is Resource.Loaded -> {
+                    MainContent(
+                        recommendations = recommendations.data,
+                        discoverInteractions = discoverInteractions,
+                    )
+                }
+
+                is Resource.Loading -> {
+                    MaxSizeLoading()
+                }
+
+                is Resource.Error -> {
+                    GenericError(
+                        onRetryClicked = {
+                            discoverInteractions.onRetryClicked()
+                        }
+                    )
+                }
             }
         }
-
     }
 }
 

--- a/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadNavigation.kt
+++ b/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadNavigation.kt
@@ -1,13 +1,11 @@
 package org.mozilla.social.feature.thread
 
-import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import org.mozilla.social.core.navigation.NavigationDestination
-
 
 fun NavController.navigateToThread(
     navOptions: NavOptions? = null,
@@ -24,12 +22,6 @@ fun NavGraphBuilder.threadScreen() {
                 nullable = true
             }
         ),
-        enterTransition = {
-            slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Up)
-        },
-        exitTransition = {
-            slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
-        },
     ) {
         val threadStatusId: String? = it.arguments?.getString(NavigationDestination.Thread.NAV_PARAM_STATUS_ID)
         threadStatusId?.let {


### PR DESCRIPTION
Fixing a handful of things

- Fixing top app bar color
- Making a back arrow the default back button for the top app bar
- Setting the screen fade animation duration to 250.  100 was too fast
- Removing the slide up animation for the thread screen (@devotaaabel slide up felt odd to me here, lmk if this is okay with you)
- Fixing window inset padding on the discover and account screen.
- Adding a divider to the top of the bottom bar
- Fixing a bug with screen rotation