### PR TITLE
Fixed landscape LoginScreen and NewPostScreen

### DIFF
--- a/feature/auth/src/main/java/org/mozilla/social/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/main/java/org/mozilla/social/feature/auth/LoginScreen.kt
@@ -51,7 +51,7 @@ private fun LoginScreen(defaultUrl: String, onLoginClicked: (String) -> Unit) {
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(modifier = Modifier.padding(80.dp))
+        Spacer(modifier = Modifier.weight(2f))
         Text(
             text = stringResource(id = R.string.title_text),
             fontSize = 30.sp
@@ -63,8 +63,9 @@ private fun LoginScreen(defaultUrl: String, onLoginClicked: (String) -> Unit) {
                 .fillMaxWidth()
                 .wrapContentHeight(),
             value = text, singleLine = true, onValueChange = { text = it })
-        Spacer(modifier = Modifier.padding(80.dp))
+        Spacer(modifier = Modifier.weight(1f))
         LoginButton(onLoginClicked = { onLoginClicked(text) })
+        Spacer(modifier = Modifier.weight(2f))
     }
 }
 

--- a/feature/post/build.gradle.kts
+++ b/feature/post/build.gradle.kts
@@ -18,8 +18,10 @@ dependencies {
     implementation(project(":core:navigation"))
 
     implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.navigation.compose)
     implementation(libs.koin.core)
     implementation(libs.koin.androidx.compose)
     implementation(libs.coil)
+
+    // The version catalog doesn't like that this ends in a "class"
+    implementation("androidx.compose.material3:material3-window-size-class")
 }


### PR DESCRIPTION
New post before
![new_post_before](https://github.com/MozillaSocial/mozilla-social-android/assets/14295757/6ce9e209-fe1f-4aa1-b95b-a7864268437a)
New Post after (There's definitely room for improvement, but at least you can see the text now)
![landscape_new_post](https://github.com/MozillaSocial/mozilla-social-android/assets/14295757/0b2b73e8-4c40-43c1-9bc0-b20f53704a08)
Login before
![login before](https://github.com/MozillaSocial/mozilla-social-android/assets/14295757/f36d322f-e260-41e4-8dd9-a79bd8745c9a)
Login after (This is going to be updated soon anyway but figured I'd fix it)
![login screenshot](https://github.com/MozillaSocial/mozilla-social-android/assets/14295757/addefa31-edac-43b0-b499-f1454733974f)

