### PR TITLE
fixing timelines

### DIFF
--- a/core/data/src/main/java/org/mozilla/social/core/data/repository/model/status/StatusPagingWrapper.kt
+++ b/core/data/src/main/java/org/mozilla/social/core/data/repository/model/status/StatusPagingWrapper.kt
@@ -1,0 +1,9 @@
+package org.mozilla.social.core.data.repository.model.status
+
+import org.mozilla.social.common.MastodonPagingLink
+import org.mozilla.social.model.Status
+
+data class StatusPagingWrapper(
+    val statuses: List<Status>,
+    val pagingLinks: List<MastodonPagingLink>?,
+)

--- a/core/domain/src/main/java/org/mozilla/social/core/domain/GetDetailedAccount.kt
+++ b/core/domain/src/main/java/org/mozilla/social/core/domain/GetDetailedAccount.kt
@@ -49,6 +49,7 @@ class GetDetailedAccount(
                     socialDatabase.relationshipsDao().insert(relationship.first().toDatabaseModel())
                 }
             } catch (e: Exception) {
+                Timber.e(e)
                 exception = e
             } finally {
                 mutex.unlock()

--- a/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
+++ b/core/network/src/main/java/org/mozilla/social/core/network/AccountApi.kt
@@ -65,7 +65,7 @@ interface AccountApi {
         @Query("only_media") onlyMedia: Boolean = false,
         @Query("exclude_replies") excludeReplies: Boolean = false,
         @Query("exclude_reblogs") excludeBoosts: Boolean = false,
-    ): List<NetworkStatus>
+    ): Response<List<NetworkStatus>>
 
     @GET("/api/v1/bookmarks")
     suspend fun getAccountBookmarks(): List<NetworkStatus>

--- a/core/network/src/main/java/org/mozilla/social/core/network/TimelineApi.kt
+++ b/core/network/src/main/java/org/mozilla/social/core/network/TimelineApi.kt
@@ -1,6 +1,7 @@
 package org.mozilla.social.core.network
 
 import org.mozilla.social.core.network.model.NetworkStatus
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -16,7 +17,7 @@ interface TimelineApi {
         @Query("min_id") immediatelyNewerThanId: String? = null,
         // Maximum number of results to return. Defaults to 20 statuses. Max 40 statuses.
         @Query("limit") limit: Int? = null,
-    ): List<NetworkStatus>
+    ): Response<List<NetworkStatus>>
 
     @GET("/api/v1/timelines/public")
     suspend fun getPublicTimeline(
@@ -31,7 +32,7 @@ interface TimelineApi {
         @Query("min_id") immediatelyNewerThanId: String? = null,
         // Maximum number of results to return. Defaults to 20 statuses. Max 40 statuses.
         @Query("limit") limit: Int? = null,
-    ): List<NetworkStatus>
+    ): Response<List<NetworkStatus>>
 
     @GET("/api/v1/timelines/tag/{hashtag}")
     suspend fun getHashTagTimeline(
@@ -44,5 +45,5 @@ interface TimelineApi {
         @Query("min_id") immediatelyNewerThanId: String? = null,
         // Maximum number of results to return. Defaults to 20 statuses. Max 40 statuses.
         @Query("limit") limit: Int? = null,
-    ): List<NetworkStatus>
+    ): Response<List<NetworkStatus>>
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2ViewModel.kt
@@ -55,7 +55,7 @@ class ReportScreen2ViewModel(
                     accountId = reportAccountId,
                     loadSize = 40,
                     excludeBoosts = true,
-                ).map {
+                ).statuses.map {
                     it.toReportStatusUiState()
                 }.filterNot {
                     it.statusId == reportStatusId


### PR DESCRIPTION
For some reason, I started getting 19 statuses back from the API during home timeline paging, even though I'm requesting 20.  Our current logic is that if the response count != the request page size, that means we are done paging.  We should instead be checking if there is a `next` link header.

- Updating all timelines to grab to look at the link header for determining if we should continue paging