### PR TITLE
Show display name on post cards

### DIFF
--- a/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardMapping.kt
+++ b/core/ui/src/main/java/org/mozilla/social/core/ui/postcard/PostCardMapping.kt
@@ -36,7 +36,7 @@ private fun Status.toMainPostCardUiState(
         replyCount = repliesCount,
         boostCount = boostsCount,
         favoriteCount = favouritesCount,
-        username = account.username,
+        username = account.displayName,
         statusId = statusId,
         userBoosted = isBoosted ?: false,
         isFavorited = isFavourited ?: false,


### PR DESCRIPTION
- Showing display name on post cards instead of username