### PR TITLE
New post fixes

### DIFF
--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
@@ -411,7 +411,7 @@ private fun MainBox(
                     }
 
                     item {
-                        val highlightColor = FirefoxColor.Blue60
+                        val highlightColor = MoSoTheme.colors.textLink
                         MoSoTextField(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/feature/post/src/main/java/org/mozilla/social/post/status/SearchBar.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/status/SearchBar.kt
@@ -51,9 +51,9 @@ fun AccountSearchBar(
                                 color =  MoSoTheme.colors.borderPrimary,
                                 shape = RoundedCornerShape(4.dp)
                             )
-                            .padding(4.dp)
                             .align(Alignment.Center)
-                            .clickable { statusInteractions.onAccountClicked(account.accountId) },
+                            .clickable { statusInteractions.onAccountClicked(account.accountId) }
+                            .padding(4.dp),
                     ) {
                         AsyncImage(
                             modifier = Modifier
@@ -109,9 +109,9 @@ fun HashtagSearchBar(
                                 color =  MoSoTheme.colors.borderPrimary,
                                 shape = RoundedCornerShape(4.dp)
                             )
-                            .padding(4.dp)
                             .align(Alignment.Center)
-                            .clickable { statusInteractions.onHashtagClicked(hashTag) },
+                            .clickable { statusInteractions.onHashtagClicked(hashTag) }
+                            .padding(4.dp),
                     ) {
                         Text(
                             modifier = Modifier


### PR DESCRIPTION
- Fixing hashtag / account highlight color
- Making account / hashtag search bar click ripple extend to the borders of the buttons