### PR TITLE
Fixing preview issue + edit account label

### DIFF
--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/appbar/MoSoTopBar.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/appbar/MoSoTopBar.kt
@@ -33,7 +33,6 @@ import org.mozilla.social.core.navigation.usecases.PopNavBackstack
  * @param title
  * @param showCloseButton
  * @param popBackstack
- * @param leftSideContent
  * @param actions
  * @param showDivider
  */
@@ -41,14 +40,14 @@ import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 fun MoSoCloseableTopAppBar(
     title: String = "",
     showCloseButton: Boolean = true,
-    popBackstack: PopNavBackstack = koinInject(),
+    onIconClicked: () -> Unit,
     actions: @Composable () -> Unit = {},
     showDivider: Boolean = false,
 ) {
     MoSoTopBar(
         title = title,
         icon = if (showCloseButton) MoSoIcons.backArrow() else null,
-        onIconClicked = { popBackstack() },
+        onIconClicked = onIconClicked,
         actions = actions,
         showDivider = showDivider
     )
@@ -152,7 +151,8 @@ private fun MoSoTopBarPreview() {
             title = "test",
             actions = {
                 Text(text = "rightSide")
-            }
+            },
+            onIconClicked = {},
         )
     }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountInteractions.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountInteractions.kt
@@ -7,6 +7,6 @@ interface AccountInteractions : OverflowInteractions {
     fun onUnfollowClicked() = Unit
     fun onRetryClicked() = Unit
     fun onTabClicked(timelineType: TimelineType) = Unit
-    fun onSettingsClicked()
+    fun onSettingsClicked() = Unit
     fun onEditAccountClicked() = Unit
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -50,10 +50,17 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.toJavaLocalDateTime
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.common.Resource
 import org.mozilla.social.common.utils.DateTimeFormatters
@@ -69,6 +76,7 @@ import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.icon.MoSoIcons
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.designsystem.utils.NoRipple
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.DropDownItem
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.core.ui.common.error.GenericError
@@ -82,6 +90,7 @@ import org.mozilla.social.core.ui.postcard.PostCardUiState
 internal fun AccountScreen(
     windowInsets: WindowInsets = WindowInsets.systemBars,
     accountId: String?,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: AccountViewModel = koinViewModel(parameters = { parametersOf(accountId) }),
 ) {
     AccountScreen(
@@ -95,6 +104,7 @@ internal fun AccountScreen(
         postCardInteractions = viewModel.postCardDelegate,
         accountInteractions = viewModel,
         windowInsets = windowInsets,
+        onBackClicked = { popBackstack() }
     )
 
     LaunchedEffect(Unit) {
@@ -116,6 +126,7 @@ private fun AccountScreen(
     postCardInteractions: PostCardInteractions,
     accountInteractions: AccountInteractions,
     windowInsets: WindowInsets,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
         Column(
@@ -124,7 +135,10 @@ private fun AccountScreen(
         ) {
             when (resource) {
                 is Resource.Loading -> {
-                    MoSoCloseableTopAppBar(showCloseButton = closeButtonVisible)
+                    MoSoCloseableTopAppBar(
+                        showCloseButton = closeButtonVisible,
+                        onIconClicked = onBackClicked,
+                    )
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -149,6 +163,7 @@ private fun AccountScreen(
                             )
                         },
                         showDivider = false,
+                        onIconClicked = onBackClicked,
                     )
 
                     MainContent(
@@ -164,7 +179,10 @@ private fun AccountScreen(
                 }
 
                 is Resource.Error -> {
-                    MoSoCloseableTopAppBar(showCloseButton = closeButtonVisible)
+                    MoSoCloseableTopAppBar(
+                        showCloseButton = closeButtonVisible,
+                        onIconClicked = onBackClicked,
+                    )
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -568,6 +586,41 @@ private const val BIO_MAX_LINES_NOT_EXPANDED = 3
 @Composable
 fun AccountScreenPreview() {
     MoSoTheme {
-//        AccountScreen("110810174933375392")
+        AccountScreen(
+            resource = Resource.Loaded(
+                data = AccountUiState(
+                    accountId = "",
+                    username = "Coolguy",
+                    webFinger = "@coolguy",
+                    displayName = "Cool Guy",
+                    accountUrl = "",
+                    bio = "I'm pretty cool",
+                    avatarUrl = "",
+                    headerUrl = "",
+                    followersCount = 1,
+                    followingCount = 500,
+                    statusesCount = 4000,
+                    fields = listOf(),
+                    isBot = false,
+                    isFollowing = false,
+                    isMuted = false,
+                    isBlocked = false,
+                    joinDate = LocalDateTime(
+                        LocalDate(2023, 7, 3),
+                        LocalTime(0, 0, 0)
+                    ),
+                )
+            ),
+            closeButtonVisible = true,
+            isUsersProfile = false,
+            feed = flowOf(),
+            errorToastMessage = MutableSharedFlow(),
+            timelineTypeFlow = MutableStateFlow(TimelineType.POSTS),
+            htmlContentInteractions = object : HtmlContentInteractions {},
+            postCardInteractions = object : PostCardInteractions {},
+            accountInteractions = object : AccountInteractions {},
+            windowInsets = WindowInsets.systemBars,
+            onBackClicked = {},
+        )
     }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -582,6 +582,7 @@ private fun UserLabel(
 
 private const val BIO_MAX_LINES_NOT_EXPANDED = 3
 
+@Suppress("MagicNumber")
 @Preview
 @Composable
 fun AccountScreenPreview() {

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.font.FontWeight.Companion.W700
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.mozilla.social.common.Resource
 import org.mozilla.social.common.utils.toFile
 import org.mozilla.social.core.designsystem.component.MoSoButton
@@ -43,6 +44,7 @@ import org.mozilla.social.core.designsystem.component.MoSoTextField
 import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.icon.MoSoIcons
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.TransparentNoTouchOverlay
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.core.ui.common.error.GenericError
@@ -52,12 +54,14 @@ import org.mozilla.social.feature.account.R
 
 @Composable
 internal fun EditAccountScreen(
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: EditAccountViewModel = koinViewModel(),
 ) {
     EditAccountScreen(
         editAccountInteractions = viewModel,
         uiState = viewModel.editAccountUiState.collectAsState().value,
         isUploading = viewModel.isUploading.collectAsState().value,
+        onBackClicked = { popBackstack() },
     )
 
     MoSoToast(toastMessage = viewModel.errorToastMessage)
@@ -68,6 +72,7 @@ fun EditAccountScreen(
     editAccountInteractions: EditAccountInteractions,
     uiState: Resource<EditAccountUiState>,
     isUploading: Boolean,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface(
         modifier = Modifier
@@ -93,6 +98,7 @@ fun EditAccountScreen(
                     }
                 },
                 showDivider = false,
+                onIconClicked = onBackClicked,
             )
 
 
@@ -348,6 +354,7 @@ private fun PreviewEditAccountScreen() {
             ),
             editAccountInteractions = object : EditAccountInteractions {},
             isUploading = false,
+            onBackClicked = {},
         )
     }
 }

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountUiState.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/edit/EditAccountUiState.kt
@@ -36,7 +36,7 @@ fun Account.toUiState(): EditAccountUiState {
         fields = fields?.map {
             EditAccountUiStateField(
                 label = it.name,
-                content = it.value,
+                content = HtmlCompat.fromHtml(it.value, 0).toString(),
             )
         }?.toMutableList()?.apply {
             if (size < EditAccountViewModel.MAX_FIELDS) {

--- a/feature/followers/src/main/java/org/mozilla/social/feature/followers/FollowersScreen.kt
+++ b/feature/followers/src/main/java/org/mozilla/social/feature/followers/FollowersScreen.kt
@@ -22,10 +22,12 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.Flow
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.core.designsystem.component.MoSoDivider
 import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.account.quickview.AccountQuickView
 import org.mozilla.social.core.ui.common.account.quickview.AccountQuickViewUiState
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
@@ -38,6 +40,7 @@ import org.mozilla.social.core.ui.common.pullrefresh.rememberPullRefreshState
 internal fun FollowersScreen(
     accountId: String,
     followersScreenType: FollowerScreenType,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: FollowersViewModel = koinViewModel(
         parameters = {
             parametersOf(
@@ -51,6 +54,7 @@ internal fun FollowersScreen(
         followersScreenType = followersScreenType,
         followers = viewModel.followers,
         followersInteractions = viewModel,
+        onBackClicked = { popBackstack() }
     )
 }
 
@@ -59,6 +63,7 @@ private fun FollowersScreen(
     followersScreenType: FollowerScreenType,
     followers: Flow<PagingData<AccountQuickViewUiState>>,
     followersInteractions: FollowersInteractions,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
         Column(
@@ -71,6 +76,7 @@ private fun FollowersScreen(
                     FollowerScreenType.FOLLOWERS -> stringResource(id = R.string.followers)
                     FollowerScreenType.FOLLOWING -> stringResource(id = R.string.following)
                 },
+                onIconClicked = onBackClicked,
             )
 
             val lazyPagingItems = followers.collectAsLazyPagingItems()

--- a/feature/hashtag/src/main/java/org/mozilla/social/feature/hashtag/HashTagScreen.kt
+++ b/feature/hashtag/src/main/java/org/mozilla/social/feature/hashtag/HashTagScreen.kt
@@ -8,9 +8,11 @@ import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.designsystem.component.MoSoSurface
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.core.ui.postcard.PostCardInteractions
 import org.mozilla.social.core.ui.postcard.PostCardList
@@ -19,6 +21,7 @@ import org.mozilla.social.core.ui.postcard.PostCardUiState
 @Composable
 internal fun HashTagScreen(
     hashTag: String,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: HashTagViewModel = koinViewModel(parameters = { parametersOf(hashTag) })
 ) {
     HashTagScreen(
@@ -26,6 +29,7 @@ internal fun HashTagScreen(
         feed = viewModel.feed,
         errorToastMessage = viewModel.postCardDelegate.errorToastMessage,
         postCardInteractions = viewModel.postCardDelegate,
+        onBackClicked = { popBackstack() },
     )
 }
 
@@ -35,6 +39,7 @@ private fun HashTagScreen(
     feed: Flow<PagingData<PostCardUiState>>,
     errorToastMessage: SharedFlow<StringFactory>,
     postCardInteractions: PostCardInteractions,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
         Column(
@@ -42,6 +47,7 @@ private fun HashTagScreen(
         ) {
             MoSoCloseableTopAppBar(
                 title = "#$hashTag",
+                onIconClicked = onBackClicked,
             )
 
             PostCardList(

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.common.LoadState
 import org.mozilla.social.common.utils.buildAnnotatedStringForAccountsAndHashtags
@@ -68,10 +69,10 @@ import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.MoSoTextField
 import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.icon.MoSoIcons
-import org.mozilla.social.core.designsystem.theme.FirefoxColor
 import org.mozilla.social.core.designsystem.theme.MoSoSpacing
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.designsystem.utils.NoIndication
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.TransparentNoTouchOverlay
 import org.mozilla.social.core.ui.common.VerticalDivider
 import org.mozilla.social.core.ui.common.VisibilityDropDownButton
@@ -101,6 +102,7 @@ import org.mozilla.social.post.status.StatusInteractions
 @Composable
 internal fun NewPostScreen(
     replyStatusId: String?,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: NewPostViewModel = koinViewModel(parameters = { parametersOf(replyStatusId) })
 ) {
     NewPostScreen(
@@ -122,6 +124,7 @@ internal fun NewPostScreen(
         inReplyToAccountName = viewModel.inReplyToAccountName.collectAsState().value,
         userHeaderState = viewModel.userHeaderState.collectAsState(initial = null).value,
         bottomBarState = viewModel.bottomBarState.collectAsState().value,
+        onBackClicked = { popBackstack() },
     )
 
     MoSoToast(toastMessage = viewModel.errorToastMessage)
@@ -150,6 +153,7 @@ private fun NewPostScreen(
     hashTags: List<String>?,
     inReplyToAccountName: String?,
     userHeaderState: UserHeaderState?,
+    onBackClicked: () -> Unit,
 ) {
 
     // If the current height class is compact (prob in landscape mode)
@@ -197,7 +201,8 @@ private fun NewPostScreen(
                 accounts = accounts,
                 hashTags = hashTags,
                 inReplyToAccountName = inReplyToAccountName,
-                userHeaderState = userHeaderState
+                userHeaderState = userHeaderState,
+                onBackClicked = onBackClicked,
             )
         }
 
@@ -265,11 +270,13 @@ private fun NewPostScreenContent(
     hashTags: List<String>?,
     inReplyToAccountName: String?,
     userHeaderState: UserHeaderState?,
+    onBackClicked: () -> Unit,
 ) {
     Column {
         TopBar(
             onPostClicked = onPostClicked,
             sendButtonEnabled = sendButtonEnabled,
+            onBackClicked = onBackClicked,
         )
         userHeaderState?.let { userHeaderState ->
             UserHeader(
@@ -348,11 +355,13 @@ fun UserHeader(
 private fun TopBar(
     onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
+    onBackClicked: () -> Unit,
 ) {
     MoSoCloseableTopAppBar(
         actions = {
             PostButton(onPostClicked = onPostClicked, sendButtonEnabled = sendButtonEnabled)
-        }
+        },
+        onIconClicked = onBackClicked,
     )
 }
 
@@ -700,7 +709,8 @@ private fun NewPostScreenPreview() {
             hashTags = null,
             inReplyToAccountName = null,
             userHeaderState = UserHeaderState("", "Barack Obama"),
-            bottomBarState = BottomBarState()
+            bottomBarState = BottomBarState(),
+            onBackClicked = {},
         )
     }
 }
@@ -735,6 +745,7 @@ private fun NewPostScreenWithPollPreview() {
             inReplyToAccountName = null,
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
+            onBackClicked = {},
         )
     }
 }
@@ -764,6 +775,7 @@ private fun NewPostScreenWithContentWarningPreview() {
             inReplyToAccountName = null,
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
+            onBackClicked = {},
         )
     }
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step1/ReportScreen1.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.core.designsystem.component.MoSoButton
 import org.mozilla.social.core.designsystem.component.MoSoCheckBox
@@ -37,6 +38,7 @@ import org.mozilla.social.core.designsystem.component.MoSoTextField
 import org.mozilla.social.core.ui.common.appbar.MoSoTopBar
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.designsystem.utils.NoRipple
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.animation.ExpandingAnimation
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.feature.report.R
@@ -52,6 +54,7 @@ internal fun ReportScreen1(
     reportAccountId: String,
     reportAccountHandle: String,
     reportStatusId: String?,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: ReportScreen1ViewModel = koinViewModel(parameters = {
         parametersOf(
             onNextClicked,
@@ -74,7 +77,8 @@ internal fun ReportScreen1(
         additionalCommentText = viewModel.additionalCommentText.collectAsState().value,
         reportAccountHandle = reportAccountHandle,
         sendToExternalServer = viewModel.sendToExternalServerChecked.collectAsState().value,
-        reportInteractions = viewModel
+        reportInteractions = viewModel,
+        onBackClicked = { popBackstack() },
     )
 }
 
@@ -88,6 +92,7 @@ private fun ReportScreen1(
     reportAccountHandle: String,
     sendToExternalServer: Boolean,
     reportInteractions: ReportScreen1Interactions,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
         Column(
@@ -98,6 +103,7 @@ private fun ReportScreen1(
         ) {
             MoSoCloseableTopAppBar(
                 title = stringResource(id = R.string.report_screen_title),
+                onIconClicked = onBackClicked,
             )
             MoSoDivider()
             MainContent(
@@ -442,6 +448,7 @@ private fun ReportScreenPreview() {
             reportAccountHandle = "john@mozilla.com",
             sendToExternalServer = false,
             reportInteractions = object : ReportScreen1Interactions {},
+            onBackClicked = {},
         )
     }
 }
@@ -474,6 +481,7 @@ private fun ReportScreenPreviewDarkMode() {
             reportAccountHandle = "john@mozilla.com",
             sendToExternalServer = false,
             reportInteractions = object : ReportScreen1Interactions {},
+            onBackClicked = {},
         )
     }
 }

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step2/ReportScreen2.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.common.Resource
 import org.mozilla.social.core.designsystem.component.MoSoButton
@@ -38,6 +39,7 @@ import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.designsystem.utils.NoRipple
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.core.ui.common.error.GenericError
 import org.mozilla.social.core.ui.common.htmlcontent.HtmlContent
@@ -59,6 +61,7 @@ internal fun ReportScreen2(
     checkedInstanceRules: List<InstanceRule>,
     additionalText: String,
     sendToExternalServer: Boolean,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: ReportScreen2ViewModel = koinViewModel(parameters = {
         parametersOf(
             onCloseClicked,
@@ -79,7 +82,8 @@ internal fun ReportScreen2(
         uiState = viewModel.statuses.collectAsState().value,
         reportIsSending = viewModel.reportIsSending.collectAsState().value,
         hasPreAttachedStatus = reportStatusId != null,
-        reportInteractions = viewModel
+        reportInteractions = viewModel,
+        onBackClicked = { popBackstack() },
     )
 
     MoSoToast(toastMessage = viewModel.errorToastMessage)
@@ -92,6 +96,7 @@ private fun ReportScreen2(
     reportIsSending: Boolean,
     hasPreAttachedStatus: Boolean,
     reportInteractions: ReportScreen2Interactions,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
         Column(
@@ -101,6 +106,7 @@ private fun ReportScreen2(
         ) {
             MoSoCloseableTopAppBar(
                 title = stringResource(id = R.string.report_screen_title),
+                onIconClicked = onBackClicked,
             )
 
             TopContent(

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/step3/ReportScreen3.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight.Companion.W600
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.core.designsystem.component.MoSoButton
 import org.mozilla.social.core.designsystem.component.MoSoButtonSecondary
@@ -25,6 +26,7 @@ import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.component.MoSoToast
 import org.mozilla.social.core.designsystem.theme.MoSoRadius
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.animation.ExpandingAnimation
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.feature.report.R
@@ -36,6 +38,7 @@ internal fun ReportScreen3(
     reportAccountId: String,
     reportAccountHandle: String,
     didUserReportAccount: Boolean,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: ReportScreen3ViewModel = koinViewModel(parameters = {
         parametersOf(
             onDoneClicked,
@@ -51,6 +54,7 @@ internal fun ReportScreen3(
         muteVisible = viewModel.muteVisible.collectAsState().value,
         blockVisible = viewModel.blockVisible.collectAsState().value,
         reportInteractions = viewModel,
+        onBackClicked = { popBackstack() },
     )
 
     MoSoToast(toastMessage = viewModel.errorToastMessage)
@@ -64,6 +68,7 @@ private fun ReportScreen3(
     muteVisible: Boolean,
     blockVisible: Boolean,
     reportInteractions: ReportScreen3Interactions,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
         Column(
@@ -71,7 +76,10 @@ private fun ReportScreen3(
                 .fillMaxHeight()
                 .systemBarsPadding()
         ) {
-            MoSoCloseableTopAppBar(title = stringResource(id = R.string.report_screen_title))
+            MoSoCloseableTopAppBar(
+                title = stringResource(id = R.string.report_screen_title),
+                onIconClicked = onBackClicked,
+            )
 
             TopContent(
                 reportAccountHandle = reportAccountHandle,

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsScreen.kt
@@ -5,20 +5,24 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.KoinApplication
+import org.koin.compose.koinInject
 import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.icon.MoSoIcons
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 import org.mozilla.social.feature.settings.ui.SettingsSection
 
 @Composable
 fun SettingsScreen(
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
     SettingsScreen(
         onAccountClicked = viewModel::onAccountClicked,
         onPrivacyClicked = viewModel::onPrivacyClicked,
         onAboutClicked = viewModel::onAboutClicked,
+        onBackClicked = { popBackstack() },
     )
 }
 
@@ -27,9 +31,13 @@ fun SettingsScreen(
     onAccountClicked: () -> Unit,
     onPrivacyClicked: () -> Unit,
     onAboutClicked: () -> Unit,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
-        SettingsColumn(title = stringResource(id = R.string.settings_title)) {
+        SettingsColumn(
+            title = stringResource(id = R.string.settings_title),
+            onBackClicked = onBackClicked,
+        ) {
             SettingsSection(
                 title = stringResource(id = R.string.account_settings_title),
                 iconPainter = MoSoIcons.identificationCard(),

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
@@ -2,14 +2,22 @@ package org.mozilla.social.feature.settings.about
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import org.koin.compose.koinInject
 import org.mozilla.social.core.designsystem.component.MoSoSurface
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 
 @Composable
-fun AboutSettingsScreen() {
+fun AboutSettingsScreen(
+    popBackstack: PopNavBackstack = koinInject(),
+) {
     MoSoSurface {
-        SettingsColumn(title = stringResource(id = R.string.about_settings_title)) {
+        SettingsColumn(
+            title = stringResource(id = R.string.about_settings_title),
+            onBackClicked = { popBackstack() },
+        ) {
+
         }
     }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsScreen.kt
@@ -21,10 +21,12 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.KoinApplication
+import org.koin.compose.koinInject
 import org.mozilla.social.core.designsystem.component.MoSoButtonSecondary
 import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.theme.MoSoSpacing
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.previewModule
 import org.mozilla.social.feature.settings.ui.SettingsColumn
@@ -32,10 +34,14 @@ import org.mozilla.social.feature.settings.ui.SettingsSection
 
 @Composable
 fun AccountSettingsScreen(
-    viewModel: AccountSettingsViewModel = koinViewModel()
+    popBackstack: PopNavBackstack = koinInject(),
+    viewModel: AccountSettingsViewModel = koinViewModel(),
 ) {
     MoSoSurface {
-        SettingsColumn(title = stringResource(id = R.string.account_settings_title)) {
+        SettingsColumn(
+            title = stringResource(id = R.string.account_settings_title),
+            onBackClicked = { popBackstack() },
+        ) {
             val userHeader = viewModel.userHeader.collectAsState(initial = null).value
 
             if (userHeader != null) {

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.mozilla.social.core.designsystem.component.MoSoSurface
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 import org.mozilla.social.feature.settings.ui.SettingsGroup
@@ -15,13 +17,15 @@ import org.mozilla.social.feature.settings.ui.SettingsSwitch
 
 @Composable
 fun PrivacySettingsScreen(
-    viewModel: PrivacySettingsViewModel = koinViewModel()
+    popBackstack: PopNavBackstack = koinInject(),
+    viewModel: PrivacySettingsViewModel = koinViewModel(),
 ) {
     val isAnalyticsToggled = viewModel.allowAnalytics.collectAsState()
 
     PrivacySettingsScreen(
         isAnalyticsToggledOn = isAnalyticsToggled.value,
         toggleAnalyticsSwitch = viewModel::toggleAllowAnalytics,
+        onBackClicked = { popBackstack() },
     )
 }
 
@@ -29,9 +33,13 @@ fun PrivacySettingsScreen(
 fun PrivacySettingsScreen(
     isAnalyticsToggledOn: Boolean,
     toggleAnalyticsSwitch: () -> Unit,
+    onBackClicked: () -> Unit,
 ) {
     MoSoSurface {
-        SettingsColumn(title = stringResource(id = R.string.privacy_settings_title)) {
+        SettingsColumn(
+            title = stringResource(id = R.string.privacy_settings_title),
+            onBackClicked = onBackClicked,
+        ) {
             AllowAnalyticsSwitch(
                 initialAllowAnalytics = isAnalyticsToggledOn,
                 onAllowAnalyticsSwitchToggled = toggleAnalyticsSwitch
@@ -62,6 +70,10 @@ private fun AllowAnalyticsSwitch(
 @Composable
 private fun PrivacySettingsScreenPreview() {
     MoSoTheme {
-        PrivacySettingsScreen(isAnalyticsToggledOn = true, {})
+        PrivacySettingsScreen(
+            isAnalyticsToggledOn = true,
+            onBackClicked = {},
+            toggleAnalyticsSwitch = {},
+        )
     }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/ui/SettingsColumn.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/ui/SettingsColumn.kt
@@ -16,10 +16,14 @@ internal fun SettingsColumn(
     modifier: Modifier = Modifier.padding(MoSoSpacing.sm),
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
-    content: @Composable ColumnScope.() -> Unit
+    onBackClicked: () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
     Column {
-        MoSoCloseableTopAppBar(title = title)
+        MoSoCloseableTopAppBar(
+            title = title,
+            onIconClicked = onBackClicked,
+        )
         Column(
             modifier = modifier,
             verticalArrangement = verticalArrangement,

--- a/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadScreen.kt
@@ -7,8 +7,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.core.designsystem.component.MoSoSurface
+import org.mozilla.social.core.navigation.usecases.PopNavBackstack
 import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
 import org.mozilla.social.core.ui.postcard.PostCardList
 
@@ -16,11 +18,15 @@ import org.mozilla.social.core.ui.postcard.PostCardList
 @Composable
 internal fun ThreadScreen(
     threadStatusId: String,
+    popBackstack: PopNavBackstack = koinInject(),
     viewModel: ThreadViewModel = koinViewModel(parameters = { parametersOf(threadStatusId) })
 ) {
     MoSoSurface {
         Column(Modifier.systemBarsPadding()) {
-            MoSoCloseableTopAppBar(title = stringResource(id = R.string.thread_screen_title))
+            MoSoCloseableTopAppBar(
+                title = stringResource(id = R.string.thread_screen_title),
+                onIconClicked = { popBackstack() },
+            )
 
             PostCardList(
                 items = viewModel.statuses.collectAsState(emptyList()).value,


### PR DESCRIPTION
All screen previews that use `MoSoCloseableTopAppBar` were broken because `koinInject` is not available in previews.  The injection needs to be lifted out of the top bar composable and put in all the screens where we inject view models.

- Hoisting state for `PopNavBackstack` use case in composables
- Also fixing a bug with edit account field content (the html wasn't getting parsed)