### PR TITLE
Fixed glean crash

### DIFF
--- a/core/analytics/src/main/java/org/mozilla/social/core/analytics/glean/GleanAnalytics.kt
+++ b/core/analytics/src/main/java/org/mozilla/social/core/analytics/glean/GleanAnalytics.kt
@@ -98,7 +98,7 @@ class GleanAnalytics(
     }
 
     override fun clearLoggedInIdentifiers() {
-//        Identifiers.mastodonAccountHandle.destroy()
-//        Identifiers.mastodonAccountId.destroy()
+        Identifiers.mastodonAccountHandle.set("")
+        Identifiers.mastodonAccountId.set("")
     }
 }

--- a/core/analytics/src/main/java/org/mozilla/social/core/analytics/glean/GleanAnalytics.kt
+++ b/core/analytics/src/main/java/org/mozilla/social/core/analytics/glean/GleanAnalytics.kt
@@ -98,7 +98,7 @@ class GleanAnalytics(
     }
 
     override fun clearLoggedInIdentifiers() {
-        Identifiers.mastodonAccountHandle.destroy()
-        Identifiers.mastodonAccountId.destroy()
+//        Identifiers.mastodonAccountHandle.destroy()
+//        Identifiers.mastodonAccountId.destroy()
     }
 }


### PR DESCRIPTION
Right now the app is crashing if you log out and then immediately log back in because of these two lines that are getting called on logout. It seems like they shouldn't be called if we might need to use glean again.

```17:57:05.222  E  FATAL EXCEPTION: main
                 Process: org.mozilla.social.debug, PID: 5353
                 java.lang.IllegalStateException: StringMetric object has already been destroyed
                 	at mozilla.telemetry.glean.internal.StringMetric.set(glean.kt:5556)
                 	at org.mozilla.social.core.analytics.glean.GleanAnalytics.setMastodonAccountId(GleanAnalytics.kt:93)
                 	at org.mozilla.social.core.domain.Login.onOAuthTokenReceived(Login.kt:99)
                 	at org.mozilla.social.core.domain.Login.access$onOAuthTokenReceived(Login.kt:20)
                 	at org.mozilla.social.core.domain.Login$onOAuthTokenReceived$1.invokeSuspend(Unknown Source:15)
                 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
                 	at android.os.Handler.handleCallback(Handler.java:958)
                 	at android.os.Handler.dispatchMessage(Handler.java:99)
                 	at android.os.Looper.loopOnce(Looper.java:205)
                 	at android.os.Looper.loop(Looper.java:294)
                 	at android.app.ActivityThread.main(ActivityThread.java:8128)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:578)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:946)
                 	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@b6d40a1, Dispatchers.Main.immediate]