### PR TITLE
Setup polls with data source/repository pattern

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -15,6 +15,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:model"))
+
     implementation(libs.androidx.navigation.compose)
     implementation(libs.koin.core)
     implementation(libs.koin.androidx.compose)

--- a/core/database/src/main/java/org/mozilla/social/core/database/DatabaseModule.kt
+++ b/core/database/src/main/java/org/mozilla/social/core/database/DatabaseModule.kt
@@ -3,6 +3,8 @@ package org.mozilla.social.core.database
 import androidx.room.Room
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
+import org.mozilla.social.core.database.dao.PollsDao
+import org.mozilla.social.core.database.datasource.PollLocalDataSource
 
 val databaseModule = module {
     single {
@@ -11,4 +13,6 @@ val databaseModule = module {
             SocialDatabase::class.java, "database-social"
         ).build()
     }
+    single { get<SocialDatabase>().pollDao() }
+    single { PollLocalDataSource(get()) }
 }

--- a/core/database/src/main/java/org/mozilla/social/core/database/SocialDatabase.kt
+++ b/core/database/src/main/java/org/mozilla/social/core/database/SocialDatabase.kt
@@ -76,12 +76,13 @@ import org.mozilla.social.core.database.model.statusCollections.LocalTimelineSta
     IntListConverter::class,
     CardConverter::class,
 )
+// TODO@DA eventually make internal
 abstract class SocialDatabase : RoomDatabase() {
     abstract fun statusDao(): StatusDao
     abstract fun accountsDao(): AccountsDao
     abstract fun hashtagDao(): HashtagDao
     abstract fun homeTimelineDao(): HomeTimelineStatusDao
-    abstract fun pollDao(): PollsDao
+    internal abstract fun pollDao(): PollsDao
     abstract fun hashTagTimelineDao(): HashTagTimelineStatusDao
     abstract fun accountTimelineDao(): AccountTimelineStatusDao
     abstract fun relationshipsDao(): RelationshipsDao

--- a/core/database/src/main/java/org/mozilla/social/core/database/dao/PollsDao.kt
+++ b/core/database/src/main/java/org/mozilla/social/core/database/dao/PollsDao.kt
@@ -6,7 +6,7 @@ import androidx.room.Transaction
 import org.mozilla.social.core.database.model.DatabasePoll
 
 @Dao
-interface PollsDao : BaseDao<DatabasePoll> {
+internal interface PollsDao : BaseDao<DatabasePoll> {
     /**
      * Updates the user's own votes on a poll
      */

--- a/core/database/src/main/java/org/mozilla/social/core/database/datasource/PollLocalDataSource.kt
+++ b/core/database/src/main/java/org/mozilla/social/core/database/datasource/PollLocalDataSource.kt
@@ -1,0 +1,52 @@
+package org.mozilla.social.core.database.datasource
+
+import org.mozilla.social.core.database.dao.PollsDao
+import org.mozilla.social.core.database.model.DatabaseEmoji
+import org.mozilla.social.core.database.model.DatabasePoll
+import org.mozilla.social.core.database.model.DatabasePollOption
+import org.mozilla.social.core.model.Emoji
+import org.mozilla.social.core.model.Poll
+import org.mozilla.social.core.model.PollOption
+
+class PollLocalDataSource internal constructor(private val dao: PollsDao) {
+    fun updateOwnVotes(pollId: String, choices: List<Int>?) = dao.updateOwnVotes(
+        pollId = pollId,
+        choices = choices
+    )
+
+    suspend fun deletePoll(pollId: String) = dao.deletePoll(pollId = pollId)
+    fun insertAll(polls: List<Poll>) {
+        dao.insertAll(polls.map { it.toDatabaseModel() })
+    }
+
+    fun update(poll: Poll) = dao.update(poll.toDatabaseModel())
+}
+
+private fun Poll.toDatabaseModel(): DatabasePoll =
+    DatabasePoll(
+        pollId = pollId,
+        isExpired = isExpired,
+        allowsMultipleChoices = allowsMultipleChoices,
+        votesCount = votesCount,
+        options = options.map { it.toDatabaseModel() },
+        emojis = emojis.map { it.toDatabaseModel() },
+        expiresAt = expiresAt,
+        votersCount = votersCount,
+        hasVoted = hasVoted,
+        ownVotes = ownVotes
+    )
+
+fun Emoji.toDatabaseModel(): DatabaseEmoji =
+    DatabaseEmoji(
+        shortCode = shortCode,
+        url = url,
+        staticUrl = staticUrl,
+        isVisibleInPicker = isVisibleInPicker,
+        category = category
+    )
+
+fun PollOption.toDatabaseModel(): DatabasePollOption =
+    DatabasePollOption(
+        title = title,
+        votesCount = votesCount
+    )

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/DatabaseDelegate.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/DatabaseDelegate.kt
@@ -1,0 +1,10 @@
+package org.mozilla.social.core.repository.mastodon
+
+import androidx.room.RoomDatabase
+import androidx.room.withTransaction
+import org.mozilla.social.core.database.SocialDatabase
+
+class DatabaseDelegate(private val socialDatabase: SocialDatabase) {
+    suspend fun <R> withTransaction(block: suspend () -> R): R =
+        socialDatabase.withTransaction(block)
+}

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MastodonRepositoryModule.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MastodonRepositoryModule.kt
@@ -5,7 +5,7 @@ import org.mozilla.social.core.network.mastodon.mastodonNetworkModule
 
 fun mastodonRepositoryModule(isDebug: Boolean) = module {
     single { AuthCredentialObserver(get(), get()) }
-    single { StatusRepository(get(), get()) }
+    single { StatusRepository(get(), get(), get()) }
     single { AccountRepository(get(), get()) }
     single { TimelineRepository(get(), get()) }
     single { OauthRepository(get()) }
@@ -14,5 +14,7 @@ fun mastodonRepositoryModule(isDebug: Boolean) = module {
     single { AppRepository(get()) }
     single { InstanceRepository(get()) }
     single { ReportRepository(get()) }
+    single { DatabaseDelegate(get()) }
+    single { PollRepository(get()) }
     includes(mastodonNetworkModule(isDebug))
 }

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/PollRepository.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/PollRepository.kt
@@ -1,0 +1,18 @@
+package org.mozilla.social.core.repository.mastodon
+
+import org.mozilla.social.core.database.datasource.PollLocalDataSource
+import org.mozilla.social.core.model.Poll
+
+class PollRepository internal constructor(private val localDataSource: PollLocalDataSource) {
+    fun updateOwnVotes(pollId: String, choices: List<Int>?) = localDataSource.updateOwnVotes(
+        pollId = pollId,
+        choices = choices
+    )
+
+    suspend fun deletePoll(pollId: String) = localDataSource.deletePoll(pollId = pollId)
+    fun insertAll(polls: List<Poll>) {
+        localDataSource.insertAll(polls)
+    }
+
+    fun update(poll: Poll) = localDataSource.update(poll)
+}

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/ExternalToDatabase.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/ExternalToDatabase.kt
@@ -10,8 +10,6 @@ import org.mozilla.social.core.database.model.DatabaseFocalPoint
 import org.mozilla.social.core.database.model.DatabaseHashTag
 import org.mozilla.social.core.database.model.DatabaseHistory
 import org.mozilla.social.core.database.model.DatabaseMention
-import org.mozilla.social.core.database.model.DatabasePoll
-import org.mozilla.social.core.database.model.DatabasePollOption
 import org.mozilla.social.core.database.model.DatabaseSource
 import org.mozilla.social.core.database.model.DatabaseStatus
 import org.mozilla.social.core.database.model.DatabaseStatusVisibility
@@ -25,13 +23,11 @@ import org.mozilla.social.core.model.FocalPoint
 import org.mozilla.social.core.model.HashTag
 import org.mozilla.social.core.model.History
 import org.mozilla.social.core.model.Mention
-import org.mozilla.social.core.model.Poll
-import org.mozilla.social.core.model.PollOption
 import org.mozilla.social.core.model.Source
 import org.mozilla.social.core.model.Status
 import org.mozilla.social.core.model.StatusVisibility
 
-fun Status.toDatabaseModel(): DatabaseStatus =
+internal fun Status.toDatabaseModel(): DatabaseStatus =
     DatabaseStatus(
         statusId = statusId,
         uri = uri,
@@ -97,7 +93,7 @@ fun Account.toDatabaseModel(): DatabaseAccount = DatabaseAccount(
 )
 
 fun StatusVisibility.toDatabaseModel(): DatabaseStatusVisibility =
-    when(this) {
+    when (this) {
         StatusVisibility.Direct -> DatabaseStatusVisibility.Direct
         StatusVisibility.Private -> DatabaseStatusVisibility.Private
         StatusVisibility.Public -> DatabaseStatusVisibility.Public
@@ -117,6 +113,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
             blurHash = blurHash,
             meta = meta.toDatabaseModel(),
         )
+
         is Attachment.Gifv -> DatabaseAttachment.Gifv(
             attachmentId = attachmentId,
             url = url,
@@ -127,6 +124,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
             description = description,
             meta = meta.toDatabaseModel(),
         )
+
         is Attachment.Video -> DatabaseAttachment.Video(
             attachmentId = attachmentId,
             url = url,
@@ -138,6 +136,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
             blurHash = blurHash,
             meta = meta.toDatabaseModel(),
         )
+
         is Attachment.Audio -> DatabaseAttachment.Audio(
             attachmentId = attachmentId,
             url = url,
@@ -149,6 +148,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
             blurHash = blurHash,
             meta = meta.toDatabaseModel(),
         )
+
         is Attachment.Unknown -> DatabaseAttachment.Unknown(
             attachmentId = attachmentId,
             url = url,
@@ -254,14 +254,6 @@ fun History.toDatabaseModel(): DatabaseHistory =
         accountCount = accountCount
     )
 
-fun Emoji.toDatabaseModel(): DatabaseEmoji =
-    DatabaseEmoji(
-        shortCode = shortCode,
-        url = url,
-        staticUrl = staticUrl,
-        isVisibleInPicker = isVisibleInPicker,
-        category = category
-    )
 
 fun Application.toDatabaseModel(): DatabaseApplication =
     DatabaseApplication(
@@ -272,25 +264,16 @@ fun Application.toDatabaseModel(): DatabaseApplication =
         clientSecret = clientSecret
     )
 
-fun Poll.toDatabaseModel(): DatabasePoll =
-    DatabasePoll(
-        pollId = pollId,
-        isExpired = isExpired,
-        allowsMultipleChoices = allowsMultipleChoices,
-        votesCount = votesCount,
-        options = options.map { it.toDatabaseModel() },
-        emojis = emojis.map { it.toDatabaseModel() },
-        expiresAt = expiresAt,
-        votersCount = votersCount,
-        hasVoted = hasVoted,
-        ownVotes = ownVotes
+
+fun Emoji.toDatabaseModel(): DatabaseEmoji =
+    DatabaseEmoji(
+        shortCode = shortCode,
+        url = url,
+        staticUrl = staticUrl,
+        isVisibleInPicker = isVisibleInPicker,
+        category = category
     )
 
-fun PollOption.toDatabaseModel(): DatabasePollOption =
-    DatabasePollOption(
-        title = title,
-        votesCount = votesCount
-    )
 
 fun Field.toDatabaseModel(): DatabaseField =
     DatabaseField(
@@ -326,6 +309,7 @@ fun Card.toDatabaseModel(): DatabaseCard =
             embedUrl = embedUrl,
             blurHash = blurHash
         )
+
         is Card.Link -> DatabaseCard.Link(
             url = url,
             title = title,
@@ -341,6 +325,7 @@ fun Card.toDatabaseModel(): DatabaseCard =
             embedUrl = embedUrl,
             blurHash = blurHash
         )
+
         is Card.Photo -> DatabaseCard.Photo(
             url = url,
             title = title,
@@ -356,6 +341,7 @@ fun Card.toDatabaseModel(): DatabaseCard =
             embedUrl = embedUrl,
             blurHash = blurHash
         )
+
         is Card.Rich -> DatabaseCard.Rich(
             url = url,
             title = title,

--- a/core/repository/mastodon/src/test/java/org/mozilla/social/core/repository/mastodon/BaseRepositoryTest.kt
+++ b/core/repository/mastodon/src/test/java/org/mozilla/social/core/repository/mastodon/BaseRepositoryTest.kt
@@ -10,9 +10,9 @@ import org.mozilla.social.core.database.dao.HashTagTimelineStatusDao
 import org.mozilla.social.core.database.dao.HashtagDao
 import org.mozilla.social.core.database.dao.HomeTimelineStatusDao
 import org.mozilla.social.core.database.dao.LocalTimelineStatusDao
-import org.mozilla.social.core.database.dao.PollsDao
 import org.mozilla.social.core.database.dao.RelationshipsDao
 import org.mozilla.social.core.database.dao.StatusDao
+import org.mozilla.social.core.database.datasource.PollLocalDataSource
 import org.mozilla.social.core.network.mastodon.AccountApi
 import org.mozilla.social.core.network.mastodon.AppApi
 import org.mozilla.social.core.network.mastodon.InstanceApi
@@ -37,6 +37,7 @@ open class BaseRepositoryTest {
     protected val timelineApi = mockk<TimelineApi>(relaxed = true)
 
     protected val socialDatabase = mockk<SocialDatabase>(relaxed = true)
+    protected val pollLocalDataSource = mockk<PollLocalDataSource>(relaxed = true)
 
     protected val accountsDao = mockk<AccountsDao>(relaxed = true)
     protected val accountTimelineDao = mockk<AccountTimelineStatusDao>(relaxed = true)
@@ -45,7 +46,6 @@ open class BaseRepositoryTest {
     protected val hashTagTimelineDao = mockk<HashTagTimelineStatusDao>(relaxed = true)
     protected val homeTimelineDao = mockk<HomeTimelineStatusDao>(relaxed = true)
     protected val localTimelineDao = mockk<LocalTimelineStatusDao>(relaxed = true)
-    protected val pollsDao = mockk<PollsDao>(relaxed = true)
     protected val relationshipsDao = mockk<RelationshipsDao>(relaxed = true)
     protected val statusDao = mockk<StatusDao>(relaxed = true)
 
@@ -58,7 +58,6 @@ open class BaseRepositoryTest {
         every { socialDatabase.hashTagTimelineDao() } returns hashTagTimelineDao
         every { socialDatabase.homeTimelineDao() } returns homeTimelineDao
         every { socialDatabase.localTimelineDao() } returns localTimelineDao
-        every { socialDatabase.pollDao() } returns pollsDao
         every { socialDatabase.relationshipsDao() } returns relationshipsDao
         every { socialDatabase.statusDao() } returns statusDao
 

--- a/core/repository/mastodon/src/test/java/org/mozilla/social/core/repository/mastodon/StatusRepositoryTest.kt
+++ b/core/repository/mastodon/src/test/java/org/mozilla/social/core/repository/mastodon/StatusRepositoryTest.kt
@@ -11,6 +11,7 @@ class StatusRepositoryTest : BaseRepositoryTest() {
         subject = StatusRepository(
             statusApi = statusApi,
             socialDatabase = socialDatabase,
+            pollLocalDataSource = pollLocalDataSource,
         )
     }
 }

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
@@ -21,6 +21,7 @@ import org.mozilla.social.core.usecase.mastodon.status.BoostStatus
 import org.mozilla.social.core.usecase.mastodon.status.DeleteStatus
 import org.mozilla.social.core.usecase.mastodon.status.FavoriteStatus
 import org.mozilla.social.core.usecase.mastodon.status.PostStatus
+import org.mozilla.social.core.usecase.mastodon.status.SaveStatusToDatabase
 import org.mozilla.social.core.usecase.mastodon.status.UndoBoostStatus
 import org.mozilla.social.core.usecase.mastodon.status.UndoFavoriteStatus
 import org.mozilla.social.core.usecase.mastodon.status.VoteOnPoll
@@ -125,10 +126,11 @@ val mastodonUsecaseModule = module {
     }
     single {
         BoostStatus(
-            externalScope = get<AppScope>(),
-            statusRepository = get(),
-            showSnackbar = get(),
+            externalScope = get(),
             socialDatabase = get(),
+            statusRepository = get(),
+            databaseDelegate = get(),
+            showSnackbar = get(),
         )
     }
     single {
@@ -157,10 +159,10 @@ val mastodonUsecaseModule = module {
     }
     single {
         VoteOnPoll(
-            externalScope = get<AppScope>(),
+            externalScope = get(),
             statusRepository = get(),
+            pollRepository = get(),
             showSnackbar = get(),
-            socialDatabase = get(),
         )
     }
     single {
@@ -171,4 +173,6 @@ val mastodonUsecaseModule = module {
             socialDatabase = get(),
         )
     }
+
+    single { SaveStatusToDatabase(socialDatabase = get(), pollRepository = get()) }
 }

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/remotemediators/HashTagTimelineRemoteMediator.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/remotemediators/HashTagTimelineRemoteMediator.kt
@@ -13,12 +13,13 @@ import org.mozilla.social.core.repository.mastodon.TimelineRepository
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.database.model.statusCollections.HashTagTimelineStatus
 import org.mozilla.social.core.database.model.statusCollections.HashTagTimelineStatusWrapper
+import org.mozilla.social.core.usecase.mastodon.status.SaveStatusToDatabase
 
 @OptIn(ExperimentalPagingApi::class)
 class HashTagTimelineRemoteMediator(
     private val timelineRepository: TimelineRepository,
     private val accountRepository: AccountRepository,
-    private val statusRepository: StatusRepository,
+    private val saveStatusToDatabase: SaveStatusToDatabase,
     private val socialDatabase: SocialDatabase,
     private val hashTag: String,
 ) : RemoteMediator<Int, HashTagTimelineStatusWrapper>() {
@@ -71,7 +72,7 @@ class HashTagTimelineRemoteMediator(
                     socialDatabase.hashTagTimelineDao().deleteHashTagTimeline(hashTag)
                 }
 
-                statusRepository.saveStatusesToDatabase(result)
+                saveStatusToDatabase(result)
 
                 socialDatabase.hashTagTimelineDao().insertAll(result.map {
                     HashTagTimelineStatus(

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/status/BoostStatus.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/status/BoostStatus.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.async
 import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
+import org.mozilla.social.core.repository.mastodon.DatabaseDelegate
 import org.mozilla.social.core.repository.mastodon.StatusRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
@@ -15,6 +16,7 @@ class BoostStatus(
     private val externalScope: CoroutineScope,
     private val socialDatabase: SocialDatabase,
     private val statusRepository: StatusRepository,
+    private val databaseDelegate: DatabaseDelegate,
     private val showSnackbar: ShowSnackbar,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -23,14 +25,14 @@ class BoostStatus(
         statusId: String,
     ) = externalScope.async(dispatcherIo) {
         try {
-            socialDatabase.withTransaction {
+            databaseDelegate.withTransaction {
                 socialDatabase.statusDao().updateBoostCount(statusId, 1)
                 socialDatabase.statusDao().updateBoosted(statusId, true)
             }
             val status = statusRepository.boostStatus(statusId)
             statusRepository.saveStatusToDatabase(status)
         } catch (e: Exception) {
-            socialDatabase.withTransaction {
+            databaseDelegate.withTransaction {
                 socialDatabase.statusDao().updateBoostCount(statusId, -1)
                 socialDatabase.statusDao().updateBoosted(statusId, false)
             }

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/status/SaveStatusToDatabase.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/status/SaveStatusToDatabase.kt
@@ -1,0 +1,78 @@
+package org.mozilla.social.core.usecase.mastodon.status
+
+import androidx.room.withTransaction
+import org.mozilla.social.core.database.SocialDatabase
+import org.mozilla.social.core.database.model.DatabaseStatus
+import org.mozilla.social.core.model.Status
+import org.mozilla.social.core.repository.mastodon.PollRepository
+import org.mozilla.social.core.repository.mastodon.model.status.toDatabaseModel
+
+class SaveStatusToDatabase internal constructor(
+    private val socialDatabase: SocialDatabase,
+    private val pollRepository: PollRepository,
+) {
+    suspend operator fun invoke(vararg statuses: Status) {
+        socialDatabase.withTransaction {
+            val boostedStatuses = statuses.mapNotNull { it.boostedStatus }
+            pollRepository.insertAll(boostedStatuses.mapNotNull {
+                it.poll
+            })
+            socialDatabase.accountsDao().insertAll(boostedStatuses.map {
+                it.account.toDatabaseModel()
+            })
+            socialDatabase.statusDao().insertAll(boostedStatuses.map {
+                it.toDatabaseModel()
+            })
+
+            pollRepository.insertAll(statuses.mapNotNull {
+                it.poll
+            })
+            socialDatabase.accountsDao().insertAll(statuses.map {
+                it.account.toDatabaseModel()
+            })
+            socialDatabase.statusDao().insertAll(statuses.map {
+                it.toDatabaseModel()
+            })
+        }
+    }
+
+    suspend operator fun invoke(statuses: List<Status>) {
+        invoke(*statuses.toTypedArray())
+    }
+}
+
+private fun Status.toDatabaseModel(): DatabaseStatus =
+    DatabaseStatus(
+        statusId = statusId,
+        uri = uri,
+        createdAt = createdAt,
+        accountId = account.accountId,
+        content = content,
+        visibility = visibility.toDatabaseModel(),
+        isSensitive = isSensitive,
+        contentWarningText = contentWarningText,
+        mediaAttachments = mediaAttachments.map { it.toDatabaseModel() },
+        mentions = mentions.map { it.toDatabaseModel() },
+        hashTags = hashTags.map { it.toDatabaseModel() },
+        emojis = emojis.map { it.toDatabaseModel() },
+        boostsCount = boostsCount,
+        favouritesCount = favouritesCount,
+        repliesCount = repliesCount,
+        application = application?.toDatabaseModel(),
+        url = url,
+        inReplyToId = inReplyToId,
+        inReplyToAccountId = inReplyToAccountId,
+        inReplyToAccountName = inReplyToAccountName,
+        boostedStatusId = boostedStatus?.statusId,
+        boostedStatusAccountId = boostedStatus?.account?.accountId,
+        pollId = poll?.pollId,
+        card = card?.toDatabaseModel(),
+        language = language,
+        plainText = plainText,
+        isFavorited = isFavourited,
+        isBoosted = isBoosted,
+        isMuted = isMuted,
+        isBookmarked = isBookmarked,
+        isPinned = isPinned,
+        isBeingDeleted = isBeingDeleted,
+    )

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/status/VoteOnPoll.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/status/VoteOnPoll.kt
@@ -5,17 +5,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import org.mozilla.social.common.utils.StringFactory
-import org.mozilla.social.core.database.SocialDatabase
-import org.mozilla.social.core.navigation.usecases.ShowSnackbar
-import org.mozilla.social.core.repository.mastodon.StatusRepository
 import org.mozilla.social.core.model.PollVote
-import org.mozilla.social.core.repository.mastodon.model.status.toDatabaseModel
+import org.mozilla.social.core.navigation.usecases.ShowSnackbar
+import org.mozilla.social.core.repository.mastodon.PollRepository
+import org.mozilla.social.core.repository.mastodon.StatusRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class VoteOnPoll(
     private val externalScope: CoroutineScope,
     private val statusRepository: StatusRepository,
-    private val socialDatabase: SocialDatabase,
+    private val pollRepository: PollRepository,
     private val showSnackbar: ShowSnackbar,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -25,14 +24,14 @@ class VoteOnPoll(
         pollChoices: List<Int>,
     ) = externalScope.async(dispatcherIo) {
         try {
-            socialDatabase.pollDao().updateOwnVotes(pollId, pollChoices)
+            pollRepository.updateOwnVotes(pollId, pollChoices)
             val poll = statusRepository.voteOnPoll(
                 pollId,
                 PollVote(pollChoices),
             )
-            socialDatabase.pollDao().update(poll.toDatabaseModel())
+            pollRepository.update(poll)
         } catch (e: Exception) {
-            socialDatabase.pollDao().updateOwnVotes(pollId, null)
+            pollRepository.updateOwnVotes(pollId, null)
             showSnackbar(
                 text = StringFactory.resource(R.string.error_voting),
                 isError = true,

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/BaseUseCaseTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/BaseUseCaseTest.kt
@@ -21,15 +21,16 @@ import org.mozilla.social.core.database.dao.HashTagTimelineStatusDao
 import org.mozilla.social.core.database.dao.HashtagDao
 import org.mozilla.social.core.database.dao.HomeTimelineStatusDao
 import org.mozilla.social.core.database.dao.LocalTimelineStatusDao
-import org.mozilla.social.core.database.dao.PollsDao
 import org.mozilla.social.core.database.dao.RelationshipsDao
 import org.mozilla.social.core.database.dao.StatusDao
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
 import org.mozilla.social.core.repository.mastodon.AppRepository
+import org.mozilla.social.core.repository.mastodon.DatabaseDelegate
 import org.mozilla.social.core.repository.mastodon.InstanceRepository
 import org.mozilla.social.core.repository.mastodon.MediaRepository
 import org.mozilla.social.core.repository.mastodon.OauthRepository
+import org.mozilla.social.core.repository.mastodon.PollRepository
 import org.mozilla.social.core.repository.mastodon.ReportRepository
 import org.mozilla.social.core.repository.mastodon.SearchRepository
 import org.mozilla.social.core.repository.mastodon.StatusRepository
@@ -48,6 +49,7 @@ open class BaseUseCaseTest {
     protected val reportRepository = mockk<ReportRepository>(relaxed = true)
     protected val searchRepository = mockk<SearchRepository>(relaxed = true)
     protected val statusRepository = mockk<StatusRepository>(relaxed = true)
+    protected val pollRepository = mockk<PollRepository>(relaxed = true)
     protected val timelineRepository = mockk<TimelineRepository>(relaxed = true)
 
 
@@ -60,12 +62,12 @@ open class BaseUseCaseTest {
     protected val hashTagTimelineDao = mockk<HashTagTimelineStatusDao>(relaxed = true)
     protected val homeTimelineDao = mockk<HomeTimelineStatusDao>(relaxed = true)
     protected val localTimelineDao = mockk<LocalTimelineStatusDao>(relaxed = true)
-    protected val pollsDao = mockk<PollsDao>(relaxed = true)
     protected val relationshipsDao = mockk<RelationshipsDao>(relaxed = true)
     protected val statusDao = mockk<StatusDao>(relaxed = true)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     protected val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    protected val databaseDelegate = mockk<DatabaseDelegate>(relaxed = true)
 
     protected val showSnackbar = mockk<ShowSnackbar>(relaxed = true)
 
@@ -78,7 +80,6 @@ open class BaseUseCaseTest {
         every { socialDatabase.hashTagTimelineDao() } returns hashTagTimelineDao
         every { socialDatabase.homeTimelineDao() } returns homeTimelineDao
         every { socialDatabase.localTimelineDao() } returns localTimelineDao
-        every { socialDatabase.pollDao() } returns pollsDao
         every { socialDatabase.relationshipsDao() } returns relationshipsDao
         every { socialDatabase.statusDao() } returns statusDao
 

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/status/BoostStatusTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/status/BoostStatusTest.kt
@@ -20,6 +20,7 @@ class BoostStatusTest : BaseUseCaseTest() {
             statusRepository = statusRepository,
             socialDatabase = socialDatabase,
             dispatcherIo = testDispatcher,
+            databaseDelegate = databaseDelegate,
         )
     }
 

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/status/VoteOnPollTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/status/VoteOnPollTest.kt
@@ -29,7 +29,7 @@ class VoteOnPollTest : BaseUseCaseTest() {
             externalScope = TestScope(testDispatcher),
             showSnackbar = showSnackbar,
             statusRepository = statusRepository,
-            socialDatabase = socialDatabase,
+            pollRepository = pollRepository,
             dispatcherIo = testDispatcher,
         )
     }
@@ -48,7 +48,7 @@ class VoteOnPollTest : BaseUseCaseTest() {
                 )
             },
             verifyBlock = {
-                pollsDao.update(any())
+                pollRepository.update(any())
             },
         )
     }


### PR DESCRIPTION
I wanted to start with a simple example before I apply the pattern to the rest of the app. I can do the rest of the daos in more PRs (it might take a while, a few seem like rabbit holes).

Basically I started by making the poll dao internal in the database module, and adding a `PollLocalDataSource` class as the module's public API. Everything else should be internal, and that way we'll have an enforcement to keep the layers.

I created a new `PollRepository`, and I think we can make repositories for any single type of data. They can include either local or remote data sources (or both), and you won't really know which until you look at it. It should be pretty clear, as a repository should only really have two parameters (a `localDataSource` and/or a `remoteDataSource`). The idea is to create use cases for anything that combines multiple streams of data. 

I've also been moving single-use mapper extension functions to their usage sites and making them private. The `model` module is supposed to be the language between our modules, so mappers like this should be private or internal where it makes sense.

I think using interfaces at this point would be premature. Let's wait until we are actually in a situation that warrants it.