### PR TITLE
Blocks and mutes list part 2 - Created and populated blocks list screen with api result

### DIFF
--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextBody.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextBody.kt
@@ -1,0 +1,135 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun SmallTextBody(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.bodySmall,
+    )
+}
+
+@Composable
+fun MediumTextBody(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.bodyMedium,
+    )
+}
+
+@Composable
+fun LargeTextBody(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.bodyLarge,
+    )
+}

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextDisplay.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextDisplay.kt
@@ -1,0 +1,135 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun SmallTextDisplay(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.displaySmall,
+    )
+}
+
+@Composable
+fun MediumTextDisplay(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.displayMedium,
+    )
+}
+
+@Composable
+fun LargeTextDisplay(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.displayLarge,
+    )
+}

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextLabel.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextLabel.kt
@@ -1,0 +1,135 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun SmallTextLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.labelSmall,
+    )
+}
+
+@Composable
+fun MediumTextLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.labelMedium,
+    )
+}
+
+@Composable
+fun LargeTextLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.labelLarge,
+    )
+}

--- a/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextTitle.kt
+++ b/core/designsystem/src/main/java/org/mozilla/social/core/designsystem/component/TextTitle.kt
@@ -1,0 +1,135 @@
+package org.mozilla.social.core.designsystem.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import org.mozilla.social.core.designsystem.theme.MoSoTheme
+
+@Composable
+fun SmallTextTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.titleSmall,
+    )
+}
+
+@Composable
+fun MediumTextTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.titleMedium,
+    )
+}
+
+@Composable
+fun LargeTextTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = MoSoTheme.typography.titleLarge,
+    )
+}

--- a/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/BlocksApi.kt
+++ b/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/BlocksApi.kt
@@ -1,0 +1,10 @@
+package org.mozilla.social.core.network.mastodon
+
+import org.mozilla.social.core.network.mastodon.model.NetworkAccount
+import retrofit2.http.GET
+
+interface BlocksApi {
+    @GET("/api/v1/blocks")
+    suspend fun getBlocks(): List<NetworkAccount>
+}
+

--- a/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/MastodonNetworkModule.kt
+++ b/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/MastodonNetworkModule.kt
@@ -21,7 +21,7 @@ fun mastodonNetworkModule(isDebug: Boolean) = module {
             .connectTimeout(OKHTTP_TIMEOUT, TimeUnit.SECONDS)
             .addNetworkInterceptor(HttpLoggingInterceptor().apply {
                 level = if (isDebug) {
-                    HttpLoggingInterceptor.Level.BASIC
+                    HttpLoggingInterceptor.Level.BODY
                 } else {
                     HttpLoggingInterceptor.Level.NONE
                 }
@@ -38,14 +38,16 @@ fun mastodonNetworkModule(isDebug: Boolean) = module {
     }
 
     single { get<Retrofit>().create(AccountApi::class.java) }
+    single { get<Retrofit>().create(AppApi::class.java) }
+    single { get<Retrofit>().create(BlocksApi::class.java) }
+    single { get<Retrofit>().create(InstanceApi::class.java) }
     single { get<Retrofit>().create(MediaApi::class.java) }
+    single { get<Retrofit>().create(MutesApi::class.java) }
     single { get<Retrofit>().create(OauthApi::class.java) }
+    single { get<Retrofit>().create(ReportApi::class.java) }
     single { get<Retrofit>().create(SearchApi::class.java) }
     single { get<Retrofit>().create(StatusApi::class.java) }
     single { get<Retrofit>().create(TimelineApi::class.java) }
-    single { get<Retrofit>().create(InstanceApi::class.java) }
-    single { get<Retrofit>().create(ReportApi::class.java) }
-    single { get<Retrofit>().create(AppApi::class.java) }
 }
 
 private var json: Json = Json { ignoreUnknownKeys = true }

--- a/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/MutesApi.kt
+++ b/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/MutesApi.kt
@@ -1,0 +1,9 @@
+package org.mozilla.social.core.network.mastodon
+
+import org.mozilla.social.core.network.mastodon.model.NetworkAccount
+import retrofit2.http.GET
+
+interface MutesApi {
+    @GET("/api/v1/mutes")
+    suspend fun getMutes(): List<NetworkAccount>
+}

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/BlocksRepository.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/BlocksRepository.kt
@@ -1,0 +1,8 @@
+package org.mozilla.social.core.repository.mastodon
+
+import org.mozilla.social.core.network.mastodon.BlocksApi
+import org.mozilla.social.core.repository.mastodon.model.status.toExternalModel
+
+class BlocksRepository(private val api: BlocksApi) {
+    suspend fun getBlocks() = api.getBlocks().map { it.toExternalModel() }
+}

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MastodonRepositoryModule.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MastodonRepositoryModule.kt
@@ -20,5 +20,7 @@ fun mastodonRepositoryModule(isDebug: Boolean) = module {
     singleOf(::FollowersRepository)
     singleOf(::FollowingsRepository)
     singleOf(::RelationshipRepository)
+    singleOf(::MutesRepository)
+    singleOf(::BlocksRepository)
     includes(mastodonNetworkModule(isDebug))
 }

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MutesRepository.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MutesRepository.kt
@@ -1,0 +1,8 @@
+package org.mozilla.social.core.repository.mastodon
+
+import org.mozilla.social.core.network.mastodon.MutesApi
+import org.mozilla.social.core.repository.mastodon.model.status.toExternalModel
+
+class MutesRepository(private val api: MutesApi) {
+    suspend fun getMutes() = api.getMutes().map { it.toExternalModel() }
+}

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/account/quickview/AccountQuickView.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/account/quickview/AccountQuickView.kt
@@ -7,16 +7,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import org.mozilla.social.core.designsystem.component.LargeTextBody
+import org.mozilla.social.core.designsystem.component.MediumTextBody
 import org.mozilla.social.core.designsystem.theme.MoSoSpacing
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
-import org.mozilla.social.core.designsystem.theme.defaultTypography
 import org.mozilla.social.core.ui.common.utils.PreviewTheme
 
 @Composable
@@ -31,8 +31,8 @@ fun AccountQuickView(
         Spacer(modifier = Modifier.width(MoSoSpacing.sm))
 
         Column {
-            DisplayName(displayName = uiState.displayName)
-            WebFinger(webFinger = uiState.webFinger)
+            LargeTextBody(text = uiState.displayName)
+            MediumTextBody(text = "@${uiState.webFinger}")
         }
 
         Spacer(modifier = Modifier.weight(1f))
@@ -42,23 +42,6 @@ fun AccountQuickView(
 }
 
 val CIRCLE_AVATAR_SIZE = 50.dp
-
-@Composable
-private fun DisplayName(modifier: Modifier = Modifier, displayName: String) {
-    Text(
-        modifier = modifier,
-        text = displayName,
-        style = defaultTypography.bodyLarge
-    )
-}
-
-@Composable
-private fun WebFinger(webFinger: String) {
-    Text(
-        text = "@${webFinger}",
-        style = defaultTypography.bodyMedium
-    )
-}
 
 @Composable
 private fun CircleAvatar(avatarUrl: String, modifier: Modifier = Modifier) {

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/account/quickview/AccountQuickView.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/account/quickview/AccountQuickView.kt
@@ -1,17 +1,12 @@
 package org.mozilla.social.core.ui.common.account.quickview
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -19,6 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import org.mozilla.social.core.designsystem.theme.MoSoSpacing
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.designsystem.theme.defaultTypography
 import org.mozilla.social.core.ui.common.utils.PreviewTheme
@@ -26,45 +22,54 @@ import org.mozilla.social.core.ui.common.utils.PreviewTheme
 @Composable
 fun AccountQuickView(
     uiState: AccountQuickViewUiState,
-    onClick: (accountId: String,) -> Unit,
+    modifier: Modifier = Modifier,
+    buttonSlot: @Composable () -> Unit = {},
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onClick(uiState.accountId) }
-    ) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
-        ) {
-            Row {
-                AsyncImage(
-                    modifier = Modifier
-                        .height(50.dp)
-                        .width(50.dp)
-                        .clip(CircleShape)
-                        .background(MoSoTheme.colors.layer2),
-                    model = uiState.avatarUrl,
-                    contentDescription = null,
-                )
-                Column(
-                    modifier = Modifier
-                        .padding(start = 16.dp)
-                ) {
-                    Text(
-                        text = uiState.displayName,
-                        style = defaultTypography.bodyLarge
-                    )
-                    Text(
-                        text = "@${uiState.webFinger}",
-                        style = defaultTypography.bodyMedium
-                    )
-                }
-            }
+    Row(modifier = modifier) {
+        CircleAvatar(uiState.avatarUrl)
+
+        Spacer(modifier = Modifier.width(MoSoSpacing.sm))
+
+        Column {
+            DisplayName(displayName = uiState.displayName)
+            WebFinger(webFinger = uiState.webFinger)
         }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        buttonSlot()
     }
+}
+
+val CIRCLE_AVATAR_SIZE = 50.dp
+
+@Composable
+private fun DisplayName(modifier: Modifier = Modifier, displayName: String) {
+    Text(
+        modifier = modifier,
+        text = displayName,
+        style = defaultTypography.bodyLarge
+    )
+}
+
+@Composable
+private fun WebFinger(webFinger: String) {
+    Text(
+        text = "@${webFinger}",
+        style = defaultTypography.bodyMedium
+    )
+}
+
+@Composable
+private fun CircleAvatar(avatarUrl: String, modifier: Modifier = Modifier) {
+    AsyncImage(
+        modifier = modifier
+            .size(CIRCLE_AVATAR_SIZE)
+            .clip(CircleShape)
+            .background(MoSoTheme.colors.layer2),
+        model = avatarUrl,
+        contentDescription = null,
+    )
 }
 
 @Preview
@@ -79,7 +84,6 @@ private fun AccountQuickViewPreview() {
                 avatarUrl = "url",
                 isFollowing = false,
             ),
-            onClick = {}
         )
     }
 }

--- a/feature/followers/src/main/java/org/mozilla/social/feature/followers/FollowersScreen.kt
+++ b/feature/followers/src/main/java/org/mozilla/social/feature/followers/FollowersScreen.kt
@@ -1,6 +1,7 @@
 package org.mozilla.social.feature.followers
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -104,6 +105,7 @@ private fun FollowersScreen(
                                 text = when (tabType) {
                                     FollowType.FOLLOWERS ->
                                         stringResource(id = R.string.followers)
+
                                     FollowType.FOLLOWING ->
                                         stringResource(id = R.string.following)
                                 },
@@ -155,7 +157,10 @@ private fun FollowersList(
                     lazyPagingItems[index]?.let { uiState ->
                         AccountQuickView(
                             uiState = uiState,
-                            onClick = followersInteractions::onAccountClicked
+                            modifier = Modifier.clickable {
+                                followersInteractions
+                                    .onAccountClicked(accountId = uiState.accountId)
+                            }
                         )
                     }
                 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
@@ -1,10 +1,13 @@
 package org.mozilla.social.feature.settings
 
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 import org.mozilla.social.feature.settings.about.AboutSettingsViewModel
 import org.mozilla.social.feature.settings.account.AccountSettingsViewModel
 import org.mozilla.social.feature.settings.contentpreferences.ContentPreferencesSettingsViewModel
+import org.mozilla.social.feature.settings.contentpreferences.blockedusers.BlockedUsersViewModel
+import org.mozilla.social.feature.settings.contentpreferences.mutedusers.MutedUsersSettingsViewModel
 import org.mozilla.social.feature.settings.privacy.PrivacySettingsViewModel
 
 val settingsModule = module {
@@ -13,4 +16,7 @@ val settingsModule = module {
     viewModel { PrivacySettingsViewModel(get()) }
     viewModel { AboutSettingsViewModel(get()) }
     viewModel { ContentPreferencesSettingsViewModel(get()) }
+    viewModel { BlockedUsersViewModel(get()) }
+    viewModelOf(::BlockedUsersViewModel)
+    viewModelOf(::MutedUsersSettingsViewModel)
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
@@ -16,7 +16,6 @@ val settingsModule = module {
     viewModel { PrivacySettingsViewModel(get()) }
     viewModel { AboutSettingsViewModel(get()) }
     viewModel { ContentPreferencesSettingsViewModel(get()) }
-    viewModel { BlockedUsersViewModel(get()) }
     viewModelOf(::BlockedUsersViewModel)
     viewModelOf(::MutedUsersSettingsViewModel)
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
@@ -75,7 +75,7 @@ fun AboutSettingsScreen(aboutSettings: AboutSettings) {
                     text = stringResource(id = R.string.administered_by),
                     style = MoSoTheme.typography.titleSmall,
                 )
-                AccountQuickView(uiState = state, onClick = {})
+                AccountQuickView(uiState = state)
             }
 
             Divider()

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersSettingsScreen.kt
@@ -1,16 +1,65 @@
 package org.mozilla.social.feature.settings.contentpreferences.blockedusers
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.androidx.compose.koinViewModel
+import org.mozilla.social.core.designsystem.component.MoSoButtonSecondary
 import org.mozilla.social.core.designsystem.component.MoSoSurface
+import org.mozilla.social.core.designsystem.component.SmallTextLabel
+import org.mozilla.social.core.ui.common.account.quickview.AccountQuickView
+import org.mozilla.social.core.ui.common.account.quickview.AccountQuickViewUiState
 import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 
 @Composable
-fun BlockedUsersSettingsScreen() {
+fun BlockedUsersSettingsScreen(viewModel: BlockedUsersViewModel = koinViewModel()) {
+    val blocks by viewModel.blocks.collectAsStateWithLifecycle(initialValue = listOf())
+    BlockedUsersSettingsScreen(blocks, viewModel::onBlockButtonClicked)
+}
+
+@Composable
+fun BlockedUsersSettingsScreen(
+    blocks: List<Block>,
+    onClick: (accountId: String) -> Unit,
+) {
     MoSoSurface {
         SettingsColumn(title = stringResource(id = R.string.blocked_users_title)) {
-
+            for (block in blocks) {
+                BlockedUserRow(block = block, onClick = onClick)
+            }
         }
     }
 }
+
+@Composable
+fun BlockedUserRow(
+    block: Block,
+    onClick: (accountId: String) -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+    ) {
+        AccountQuickView(
+            uiState = block.quickViewUiState,
+            modifier = Modifier.fillMaxWidth(),
+            buttonSlot = {
+                MoSoButtonSecondary(
+                    enabled = false,
+                    onClick = { onClick(block.quickViewUiState.accountId) },
+                ) { SmallTextLabel(text = stringResource(id = R.string.unblock)) }
+            },
+        )
+    }
+}
+
+data class Block(
+    val quickViewUiState: AccountQuickViewUiState,
+)

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
@@ -1,0 +1,28 @@
+package org.mozilla.social.feature.settings.contentpreferences.blockedusers
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.mozilla.social.core.model.Account
+import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.BlocksRepository
+import org.mozilla.social.core.ui.common.account.quickview.toQuickViewUiState
+
+class BlockedUsersViewModel(
+    private val repository: BlocksRepository,
+    private val accountRepository: AccountRepository,
+) : ViewModel() {
+
+    val blocks: Flow<List<Block>> = flow {
+        emit(repository.getBlocks().map { it.toBlock() })
+    }
+
+    // TODO@DA hook up
+    suspend fun onBlockButtonClicked(accountId: String) {
+        accountRepository.muteAccount(accountId)
+    }
+}
+
+private fun Account.toBlock(): Block {
+    return Block(toQuickViewUiState())
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
@@ -1,8 +1,12 @@
 package org.mozilla.social.feature.settings.contentpreferences.blockedusers
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import org.mozilla.social.core.model.Account
 import org.mozilla.social.core.repository.mastodon.AccountRepository
 import org.mozilla.social.core.repository.mastodon.BlocksRepository
@@ -11,15 +15,16 @@ import org.mozilla.social.core.ui.common.account.quickview.toQuickViewUiState
 class BlockedUsersViewModel(
     private val repository: BlocksRepository,
     private val accountRepository: AccountRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     val blocks: Flow<List<Block>> = flow {
         emit(repository.getBlocks().map { it.toBlock() })
     }
 
-    // TODO@DA hook up
-    suspend fun onBlockButtonClicked(accountId: String) {
-        accountRepository.muteAccount(accountId)
+    // TODO@DA error handling and unblock
+    fun onBlockButtonClicked(accountId: String) {
+        viewModelScope.launch(ioDispatcher) { accountRepository.muteAccount(accountId) }
     }
 }
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
@@ -1,0 +1,24 @@
+package org.mozilla.social.feature.settings.contentpreferences.mutedusers
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.mozilla.social.core.model.Account
+import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.MutesRepository
+
+class MutedUsersSettingsViewModel(
+    private val repository: MutesRepository,
+    private val accountRepository: AccountRepository,
+): ViewModel() {
+
+    val mutes: Flow<List<Account>> = flow<List<Account>> {
+        emit(repository.getMutes())
+    }
+
+    // TODO@DA hook up
+    suspend fun onMuteButtonClicked(accountId: String) {
+        accountRepository.muteAccount(accountId)
+    }
+}
+

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
@@ -1,8 +1,12 @@
 package org.mozilla.social.feature.settings.contentpreferences.mutedusers
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import org.mozilla.social.core.model.Account
 import org.mozilla.social.core.repository.mastodon.AccountRepository
 import org.mozilla.social.core.repository.mastodon.MutesRepository
@@ -10,15 +14,18 @@ import org.mozilla.social.core.repository.mastodon.MutesRepository
 class MutedUsersSettingsViewModel(
     private val repository: MutesRepository,
     private val accountRepository: AccountRepository,
-): ViewModel() {
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ViewModel() {
 
     val mutes: Flow<List<Account>> = flow<List<Account>> {
         emit(repository.getMutes())
     }
 
     // TODO@DA hook up
-    suspend fun onMuteButtonClicked(accountId: String) {
-        accountRepository.muteAccount(accountId)
+    fun onMuteButtonClicked(
+        accountId: String,
+    ) {
+        viewModelScope.launch(ioDispatcher) { accountRepository.muteAccount(accountId) }
     }
 }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="data_collection_description">Allow technical, interaction, campaign and referral data to be sent to Mozilla. With this data you will have a personalized experience.</string>
 
     <string name="sign_out">Sign Out</string>
+    <string name="unblock">Unblock</string>
 </resources>


### PR DESCRIPTION
I've been reading the [API guidelines for compose](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-component-api-guidelines.md#component_s-purpose), and I've tried to implement a few suggestions in this PR:
- Created separate named styled text composables (see `SmallTextLabel`, `LargeTextTitle`, etc.) instead of manually always needing to pass in style to emulate "building blocks" described in docs
- Started updating parameter order
- Added modifier to all components (as the first optional param always)
- Tried to give each component only one problem to solve
- Updated `QuickAccountView` with a button slot (and other guidelines)