### PR TITLE
fixing dep injection issue

### DIFF
--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
@@ -189,7 +189,7 @@ val mastodonUsecaseModule = module {
     single { RefreshLocalTimeline(get(), get(), get(), get()) }
     single { RefreshFederatedTimeline(get(), get(), get(), get()) }
     singleOf(::RefreshHomeTimeline)
-    single {
+    factory {
         RefreshAccountTimeline(
             accountRepository = get(),
             socialDatabase = get(),


### PR DESCRIPTION
This being a single caused all account timelines to use the same account ID