### PR TITLE
koin module fix

### DIFF
--- a/app/src/main/java/org/mozilla/social/MainApplication.kt
+++ b/app/src/main/java/org/mozilla/social/MainApplication.kt
@@ -13,16 +13,8 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
-import org.mozilla.social.common.appscope.appScopeModule
 import org.mozilla.social.core.analytics.Analytics
-import org.mozilla.social.core.analytics.analyticsModule
-import org.mozilla.social.core.database.databaseModule
-import org.mozilla.social.core.datastore.dataStoreModule
-import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.repository.mastodon.AuthCredentialObserver
-import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
-import org.mozilla.social.core.repository.mozilla.mozillaRepositoryModule
-import org.mozilla.social.core.ui.postcard.postCardModule
 import org.mozilla.social.feature.auth.authModule
 import org.mozilla.social.feature.settings.settingsModule
 import org.mozilla.social.feed.feedModule
@@ -48,7 +40,8 @@ class MainApplication : Application(), ImageLoaderFactory {
             androidLogger()
             androidContext(this@MainApplication)
             modules(
-                appModules,
+                featureModules,
+                mainModule,
             )
         }
 
@@ -71,27 +64,18 @@ class MainApplication : Application(), ImageLoaderFactory {
             .build()
 }
 
-val appModules = module {
+val featureModules = module {
     includes(
-        authModule,
-        dataStoreModule,
-        mainModule,
-        feedModule,
-        searchModule,
-        mastodonRepositoryModule(BuildConfig.DEBUG),
-        mozillaRepositoryModule(BuildConfig.DEBUG),
-        newPostModule,
-        settingsModule,
         accountModule,
-        databaseModule,
-        threadModule,
-        reportModule,
-        hashTagModule,
-        analyticsModule,
-        followersModule,
+        authModule,
         discoverModule,
-        navigationModule,
-        postCardModule,
-        appScopeModule,
+        feedModule,
+        followersModule,
+        hashTagModule,
+        newPostModule,
+        reportModule,
+        searchModule,
+        settingsModule,
+        threadModule,
     )
 }

--- a/app/src/test/java/org/mozilla/social/CheckModulesTest.kt
+++ b/app/src/test/java/org/mozilla/social/CheckModulesTest.kt
@@ -16,7 +16,7 @@ class CheckModulesTest : KoinTest {
     @OptIn(KoinExperimentalAPI::class)
     @Test
     fun checkAllModules() {
-        appModules.verify(
+        featureModules.verify(
             extraTypes = listOf(
                 Context::class,
                 CoroutineDispatcher::class,

--- a/core/analytics/src/main/java/org/mozilla/social/core/analytics/AnalyticsModule.kt
+++ b/core/analytics/src/main/java/org/mozilla/social/core/analytics/AnalyticsModule.kt
@@ -2,7 +2,11 @@ package org.mozilla.social.core.analytics
 
 import org.koin.dsl.module
 import org.mozilla.social.core.analytics.glean.GleanAnalytics
+import org.mozilla.social.core.datastore.dataStoreModule
 
 val analyticsModule = module {
+    includes(
+        dataStoreModule,
+    )
     single<Analytics> { GleanAnalytics(get()) }
 }

--- a/core/common/src/main/java/org/mozilla/social/common/CommonModule.kt
+++ b/core/common/src/main/java/org/mozilla/social/common/CommonModule.kt
@@ -1,0 +1,8 @@
+package org.mozilla.social.common
+
+import org.koin.dsl.module
+import org.mozilla.social.common.appscope.AppScope
+
+val commonModule = module {
+    single { AppScope() }
+}

--- a/core/common/src/main/java/org/mozilla/social/common/appscope/AppScopeModule.kt
+++ b/core/common/src/main/java/org/mozilla/social/common/appscope/AppScopeModule.kt
@@ -1,7 +1,0 @@
-package org.mozilla.social.common.appscope
-
-import org.koin.dsl.module
-
-val appScopeModule = module {
-    single { AppScope() }
-}

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationModule.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/NavigationModule.kt
@@ -1,6 +1,7 @@
 package org.mozilla.social.core.navigation
 
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
 import org.mozilla.social.core.navigation.usecases.NavigateTo
 import org.mozilla.social.core.navigation.usecases.OpenLink
 import org.mozilla.social.core.navigation.usecases.PopNavBackstack
@@ -8,6 +9,10 @@ import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 
 
 val navigationModule = module {
+    includes(
+        commonModule,
+    )
+
     single { EventRelay() }
     single { NavigationEventFlow(get()) }
     single { NavigateTo(get()) }

--- a/core/network/mastodon/build.gradle.kts
+++ b/core/network/mastodon/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 android {
     namespace = "org.mozilla.social.core.network.mastodon"
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/MastodonNetworkModule.kt
+++ b/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/MastodonNetworkModule.kt
@@ -11,7 +11,7 @@ import org.mozilla.social.core.network.mastodon.interceptors.AuthCredentialInter
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
 
-fun mastodonNetworkModule(isDebug: Boolean) = module {
+val mastodonNetworkModule = module {
     single { AuthCredentialInterceptor() }
     single(
         named(AUTHORIZED_CLIENT)
@@ -20,7 +20,7 @@ fun mastodonNetworkModule(isDebug: Boolean) = module {
             .readTimeout(OKHTTP_TIMEOUT, TimeUnit.SECONDS)
             .connectTimeout(OKHTTP_TIMEOUT, TimeUnit.SECONDS)
             .addNetworkInterceptor(HttpLoggingInterceptor().apply {
-                level = if (isDebug) {
+                level = if (BuildConfig.DEBUG) {
                     HttpLoggingInterceptor.Level.BODY
                 } else {
                     HttpLoggingInterceptor.Level.NONE

--- a/core/network/mozilla/build.gradle.kts
+++ b/core/network/mozilla/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 android {
     namespace = "org.mozilla.social.core.network.mozilla"
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/core/network/mozilla/src/main/java/org/mozilla/social/core/network/mozilla/MozillaNetworkModule.kt
+++ b/core/network/mozilla/src/main/java/org/mozilla/social/core/network/mozilla/MozillaNetworkModule.kt
@@ -10,14 +10,14 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
 
-fun mozillaNetworkModule(isDebug: Boolean) = module {
+val mozillaNetworkModule = module {
 
     single(named(RECCS_CLIENT)) {
         OkHttpClient.Builder()
             .readTimeout(OKHTTP_TIMEOUT, TimeUnit.SECONDS)
             .connectTimeout(OKHTTP_TIMEOUT, TimeUnit.SECONDS)
             .addNetworkInterceptor(HttpLoggingInterceptor().apply {
-                level = if (isDebug) {
+                level = if (BuildConfig.DEBUG) {
                     HttpLoggingInterceptor.Level.BASIC
                 } else {
                     HttpLoggingInterceptor.Level.NONE

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MastodonRepositoryModule.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/MastodonRepositoryModule.kt
@@ -2,9 +2,17 @@ package org.mozilla.social.core.repository.mastodon
 
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import org.mozilla.social.core.database.databaseModule
+import org.mozilla.social.core.datastore.dataStoreModule
 import org.mozilla.social.core.network.mastodon.mastodonNetworkModule
 
-fun mastodonRepositoryModule(isDebug: Boolean) = module {
+val mastodonRepositoryModule = module {
+    includes(
+        mastodonNetworkModule,
+        dataStoreModule,
+        databaseModule,
+    )
+
     single { AuthCredentialObserver(get(), get()) }
     singleOf(::StatusRepository)
     singleOf(::AccountRepository)
@@ -22,5 +30,5 @@ fun mastodonRepositoryModule(isDebug: Boolean) = module {
     singleOf(::RelationshipRepository)
     singleOf(::MutesRepository)
     singleOf(::BlocksRepository)
-    includes(mastodonNetworkModule(isDebug))
+
 }

--- a/core/repository/mozilla/src/main/java/org/mozilla/social/core/repository/mozilla/MozillaRepositoryModule.kt
+++ b/core/repository/mozilla/src/main/java/org/mozilla/social/core/repository/mozilla/MozillaRepositoryModule.kt
@@ -3,7 +3,10 @@ package org.mozilla.social.core.repository.mozilla
 import org.koin.dsl.module
 import org.mozilla.social.core.network.mozilla.mozillaNetworkModule
 
-fun mozillaRepositoryModule(isDebug: Boolean) = module {
+val mozillaRepositoryModule = module {
+    includes(
+        mozillaNetworkModule,
+    )
+
     single { RecommendationRepository(get()) }
-    includes(mozillaNetworkModule(isDebug))
 }

--- a/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardModule.kt
+++ b/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardModule.kt
@@ -1,8 +1,19 @@
 package org.mozilla.social.core.ui.postcard
 
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 
 val postCardModule = module {
+    includes(
+        commonModule,
+        mastodonRepositoryModule,
+        navigationModule,
+        mastodonUsecaseModule,
+    )
+
     factory { parametersHolder ->
         PostCardDelegate(
             coroutineScope = parametersHolder[0],

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
@@ -3,6 +3,10 @@ package org.mozilla.social.core.usecase.mastodon
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import org.mozilla.social.common.appscope.AppScope
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.database.databaseModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
 import org.mozilla.social.core.usecase.mastodon.account.BlockAccount
 import org.mozilla.social.core.usecase.mastodon.account.FollowAccount
 import org.mozilla.social.core.usecase.mastodon.account.GetDetailedAccount
@@ -34,6 +38,13 @@ import org.mozilla.social.core.usecase.mastodon.timeline.RefreshHomeTimeline
 import org.mozilla.social.core.usecase.mastodon.timeline.RefreshLocalTimeline
 
 val mastodonUsecaseModule = module {
+    includes(
+        mastodonRepositoryModule,
+        databaseModule,
+        analyticsModule,
+        navigationModule,
+    )
+
     factory { parametersHolder ->
         HashTagTimelineRemoteMediator(
             get(),

--- a/core/usecase/mozilla/src/main/java/org/mozilla/social/core/usecase/mozilla/MozillaUsecaseModule.kt
+++ b/core/usecase/mozilla/src/main/java/org/mozilla/social/core/usecase/mozilla/MozillaUsecaseModule.kt
@@ -1,8 +1,18 @@
 package org.mozilla.social.core.usecase.mozilla
 
 import org.koin.dsl.module
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.database.databaseModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mozilla.mozillaRepositoryModule
 
 val mozillaUsecaseModule = module {
+    includes(
+        mozillaRepositoryModule,
+        databaseModule,
+        analyticsModule,
+        navigationModule,
+    )
 
     single { GetRecommendations(get()) }
 

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountModule.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountModule.kt
@@ -2,9 +2,28 @@ package org.mozilla.social.feature.account
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.database.databaseModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.ui.postcard.postCardModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 import org.mozilla.social.feature.account.edit.EditAccountViewModel
 
 val accountModule = module {
+    includes(
+        commonModule,
+        dataStoreModule,
+        mastodonUsecaseModule,
+        mastodonRepositoryModule,
+        postCardModule,
+        databaseModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel { parametersHolder ->
         AccountViewModel(
             analytics = get(),

--- a/feature/auth/src/main/java/org/mozilla/social/feature/auth/AuthModule.kt
+++ b/feature/auth/src/main/java/org/mozilla/social/feature/auth/AuthModule.kt
@@ -2,10 +2,25 @@ package org.mozilla.social.feature.auth
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 import org.mozilla.social.feature.auth.chooseServer.ChooseServerViewModel
 import org.mozilla.social.feature.auth.login.LoginViewModel
 
 val authModule = module {
+    includes(
+        commonModule,
+        dataStoreModule,
+        mastodonUsecaseModule,
+        mastodonRepositoryModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel { LoginViewModel(get(), get(), get(), get()) }
     viewModel { ChooseServerViewModel(get()) }
 }

--- a/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverModule.kt
+++ b/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverModule.kt
@@ -2,15 +2,23 @@ package org.mozilla.social.feature.discover
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.usecase.mozilla.mozillaUsecaseModule
 
 val discoverModule = module {
+    includes(
+        commonModule,
+        mozillaUsecaseModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel {
         DiscoverViewModel(
             get(),
             get(),
         )
     }
-
-    includes(mozillaUsecaseModule)
 }

--- a/feature/feed/src/main/java/org/mozilla/social/feed/FeedModule.kt
+++ b/feature/feed/src/main/java/org/mozilla/social/feed/FeedModule.kt
@@ -2,12 +2,30 @@ package org.mozilla.social.feed
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.database.databaseModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.ui.postcard.postCardModule
 import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 import org.mozilla.social.feed.remoteMediators.FederatedTimelineRemoteMediator
 import org.mozilla.social.feed.remoteMediators.HomeTimelineRemoteMediator
 import org.mozilla.social.feed.remoteMediators.LocalTimelineRemoteMediator
 
 val feedModule = module {
+    includes(
+        commonModule,
+        mastodonUsecaseModule,
+        dataStoreModule,
+        mastodonRepositoryModule,
+        postCardModule,
+        databaseModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     single {
         HomeTimelineRemoteMediator(
             get(),
@@ -31,5 +49,4 @@ val feedModule = module {
         getLoggedInUserAccountId = get(),
         socialDatabase = get(),
     ) }
-    includes(mastodonUsecaseModule)
 }

--- a/feature/followers/src/main/java/org/mozilla/social/feature/followers/FollowersModule.kt
+++ b/feature/followers/src/main/java/org/mozilla/social/feature/followers/FollowersModule.kt
@@ -2,8 +2,21 @@ package org.mozilla.social.feature.followers
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 
 val followersModule = module {
+    includes(
+        commonModule,
+        mastodonUsecaseModule,
+        mastodonRepositoryModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel { parameters ->
         FollowersViewModel(
             accountId = parameters[0],

--- a/feature/hashtag/src/main/java/org/mozilla/social/feature/hashtag/HashTagModule.kt
+++ b/feature/hashtag/src/main/java/org/mozilla/social/feature/hashtag/HashTagModule.kt
@@ -2,8 +2,27 @@ package org.mozilla.social.feature.hashtag
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.database.databaseModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.ui.postcard.postCardModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 
 val hashTagModule = module {
+    includes(
+        commonModule,
+        mastodonUsecaseModule,
+        mastodonRepositoryModule,
+        dataStoreModule,
+        postCardModule,
+        databaseModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel { parametersHolder ->
         HashTagViewModel(
             hashTag = parametersHolder[0],

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
@@ -2,8 +2,23 @@ package org.mozilla.social.post
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 
 val newPostModule = module {
+    includes(
+        commonModule,
+        mastodonRepositoryModule,
+        dataStoreModule,
+        mastodonUsecaseModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel { parametersHolder ->
         NewPostViewModel(
             analytics = get(),

--- a/feature/report/src/main/java/org/mozilla/social/feature/report/ReportModule.kt
+++ b/feature/report/src/main/java/org/mozilla/social/feature/report/ReportModule.kt
@@ -2,11 +2,26 @@ package org.mozilla.social.feature.report
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 import org.mozilla.social.feature.report.step1.ReportScreen1ViewModel
 import org.mozilla.social.feature.report.step2.ReportScreen2ViewModel
 import org.mozilla.social.feature.report.step3.ReportScreen3ViewModel
 
 val reportModule = module {
+    includes(
+        commonModule,
+        mastodonRepositoryModule,
+        dataStoreModule,
+        navigationModule,
+        analyticsModule,
+        mastodonUsecaseModule,
+    )
+
     viewModel { parametersHolder ->
         ReportScreen1ViewModel(
             get(),

--- a/feature/search/src/main/java/org/mozilla/social/search/SearchModule.kt
+++ b/feature/search/src/main/java/org/mozilla/social/search/SearchModule.kt
@@ -2,7 +2,16 @@ package org.mozilla.social.search
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
 
 val searchModule = module {
+    includes(
+        dataStoreModule,
+        mastodonRepositoryModule,
+        navigationModule,
+    )
+
     viewModel { SearchViewModel(get()) }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
@@ -3,6 +3,12 @@ package org.mozilla.social.feature.settings
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 import org.mozilla.social.feature.settings.about.AboutSettingsViewModel
 import org.mozilla.social.feature.settings.account.AccountSettingsViewModel
 import org.mozilla.social.feature.settings.contentpreferences.ContentPreferencesSettingsViewModel
@@ -11,6 +17,15 @@ import org.mozilla.social.feature.settings.contentpreferences.mutedusers.MutedUs
 import org.mozilla.social.feature.settings.privacy.PrivacySettingsViewModel
 
 val settingsModule = module {
+    includes(
+        commonModule,
+        analyticsModule,
+        dataStoreModule,
+        navigationModule,
+        mastodonRepositoryModule,
+        mastodonUsecaseModule,
+    )
+
     viewModel { _ -> SettingsViewModel(get(), get(), get()) }
     viewModel { AccountSettingsViewModel(get(), get(), get()) }
     viewModel { PrivacySettingsViewModel(get()) }

--- a/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadModule.kt
+++ b/feature/thread/src/main/java/org/mozilla/social/feature/thread/ThreadModule.kt
@@ -2,8 +2,25 @@ package org.mozilla.social.feature.thread
 
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.social.common.commonModule
+import org.mozilla.social.core.analytics.analyticsModule
+import org.mozilla.social.core.datastore.dataStoreModule
+import org.mozilla.social.core.navigation.navigationModule
+import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
+import org.mozilla.social.core.ui.postcard.postCardModule
+import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
 
 val threadModule = module {
+    includes(
+        commonModule,
+        mastodonUsecaseModule,
+        mastodonRepositoryModule,
+        dataStoreModule,
+        postCardModule,
+        navigationModule,
+        analyticsModule,
+    )
+
     viewModel { parametersHolder -> ThreadViewModel(
         analytics = get(),
         getLoggedInUserAccountId = get(),


### PR DESCRIPTION
Definitions:
koin module = koin modules created with `koin.module { }`
project module = our project modules, i.e. `feature:auth` or `core:common`

We need our koin modules to include the koin modules they depend on so that our project modules can be used independently.  This is important for integration / ui tests for individual modules, as well as being necessary if we ever distribute our modules individually.

- Making sure each koin module includes the koin modules of the project modules' dependencies.
- Making the `app` module only use koin modules of project feature modules