### PR TITLE
Relationship use case updates

### DIFF
--- a/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/AccountApi.kt
+++ b/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/AccountApi.kt
@@ -76,22 +76,22 @@ interface AccountApi {
     @POST("/api/v1/accounts/{accountId}/follow")
     suspend fun followAccount(
         @Path("accountId") accountId: String,
-    )
+    ): NetworkRelationship
 
     @POST("/api/v1/accounts/{accountId}/unfollow")
     suspend fun unfollowAccount(
         @Path("accountId") accountId: String,
-    )
+    ): NetworkRelationship
 
     @POST("/api/v1/accounts/{accountId}/block")
     suspend fun blockAccount(
         @Path("accountId") accountId: String,
-    )
+    ): NetworkRelationship
 
     @POST("/api/v1/accounts/{accountId}/unblock")
     suspend fun unblockAccount(
         @Path("accountId") accountId: String,
-    )
+    ): NetworkRelationship
 
     /**
      * @param duration how long to mute for in seconds.  0 is indefinite
@@ -101,12 +101,12 @@ interface AccountApi {
     suspend fun muteAccount(
         @Path("accountId") accountId: String,
         @Field("duration") duration: Int = 0,
-    )
+    ): NetworkRelationship
 
     @POST("/api/v1/accounts/{accountId}/unmute")
     suspend fun unmuteAccount(
         @Path("accountId") accountId: String,
-    )
+    ): NetworkRelationship
 
     @GET("/api/v1/accounts/relationships")
     suspend fun getRelationships(

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/AccountRepository.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/AccountRepository.kt
@@ -110,22 +110,28 @@ class AccountRepository internal constructor(
     suspend fun getAccountFavourites(): List<Status> = api.getAccountFavourites().map { it.toExternalModel() }
 
     @PreferUseCase
-    suspend fun followAccount(accountId: String) = api.followAccount(accountId = accountId)
+    suspend fun followAccount(accountId: String): Relationship =
+        api.followAccount(accountId = accountId).toExternal()
 
     @PreferUseCase
-    suspend fun unfollowAccount(accountId: String) = api.unfollowAccount(accountId = accountId)
+    suspend fun unfollowAccount(accountId: String): Relationship =
+        api.unfollowAccount(accountId = accountId).toExternal()
 
     @PreferUseCase
-    suspend fun blockAccount(accountId: String) = api.blockAccount(accountId = accountId)
+    suspend fun blockAccount(accountId: String): Relationship =
+        api.blockAccount(accountId = accountId).toExternal()
 
     @PreferUseCase
-    suspend fun unblockAccount(accountId: String) = api.unblockAccount(accountId = accountId)
+    suspend fun unblockAccount(accountId: String): Relationship =
+        api.unblockAccount(accountId = accountId).toExternal()
 
     @PreferUseCase
-    suspend fun muteAccount(accountId: String) = api.muteAccount(accountId = accountId)
+    suspend fun muteAccount(accountId: String): Relationship =
+        api.muteAccount(accountId = accountId).toExternal()
 
     @PreferUseCase
-    suspend fun unmuteAccount(accountId: String) = api.unmuteAccount(accountId = accountId)
+    suspend fun unmuteAccount(accountId: String): Relationship =
+        api.unmuteAccount(accountId = accountId).toExternal()
 
     suspend fun getAccountRelationships(accountIds: List<String>): List<Relationship> =
         api.getRelationships(accountIds.toTypedArray()).map { it.toExternal() }

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/RelationshipRepository.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/RelationshipRepository.kt
@@ -7,5 +7,9 @@ import org.mozilla.social.core.repository.mastodon.model.account.toDatabaseModel
 class RelationshipRepository(
     private val dao: RelationshipsDao,
 ) {
-    fun insertAll(relationships: List<Relationship>) = dao.insertAll(relationships.map { it.toDatabaseModel() })
+    fun insertAll(relationships: List<Relationship>) =
+        dao.insertAll(relationships.map { it.toDatabaseModel() })
+
+    fun insert(relationship: Relationship) =
+        dao.insert(relationship.toDatabaseModel())
 }

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/MastodonUsecaseModule.kt
@@ -74,6 +74,7 @@ val mastodonUsecaseModule =
                 externalScope = get<AppScope>(),
                 showSnackbar = get(),
                 accountRepository = get(),
+                relationshipRepository = get(),
                 socialDatabase = get(),
             )
         }
@@ -82,6 +83,7 @@ val mastodonUsecaseModule =
                 externalScope = get<AppScope>(),
                 showSnackbar = get(),
                 accountRepository = get(),
+                relationshipRepository = get(),
                 socialDatabase = get(),
             )
         }
@@ -90,6 +92,7 @@ val mastodonUsecaseModule =
                 externalScope = get<AppScope>(),
                 showSnackbar = get(),
                 accountRepository = get(),
+                relationshipRepository = get(),
                 socialDatabase = get(),
             )
         }
@@ -98,6 +101,7 @@ val mastodonUsecaseModule =
                 externalScope = get<AppScope>(),
                 showSnackbar = get(),
                 accountRepository = get(),
+                relationshipRepository = get(),
                 socialDatabase = get(),
             )
         }
@@ -106,6 +110,7 @@ val mastodonUsecaseModule =
                 externalScope = get<AppScope>(),
                 showSnackbar = get(),
                 accountRepository = get(),
+                relationshipRepository = get(),
                 socialDatabase = get(),
             )
         }
@@ -114,6 +119,7 @@ val mastodonUsecaseModule =
                 externalScope = get<AppScope>(),
                 showSnackbar = get(),
                 accountRepository = get(),
+                relationshipRepository = get(),
                 socialDatabase = get(),
             )
         }

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/BlockAccount.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/BlockAccount.kt
@@ -9,12 +9,14 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class BlockAccount(
     private val externalScope: CoroutineScope,
     private val showSnackbar: ShowSnackbar,
     private val accountRepository: AccountRepository,
+    private val relationshipRepository: RelationshipRepository,
     private val socialDatabase: SocialDatabase,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -29,7 +31,8 @@ class BlockAccount(
                 socialDatabase.localTimelineDao().removePostsFromAccount(accountId)
                 socialDatabase.federatedTimelineDao().removePostsFromAccount(accountId)
                 socialDatabase.relationshipsDao().updateBlocked(accountId, true)
-                accountRepository.blockAccount(accountId)
+                val relationship = accountRepository.blockAccount(accountId)
+                relationshipRepository.insert(relationship)
             } catch (e: Exception) {
                 socialDatabase.relationshipsDao().updateBlocked(accountId, false)
                 showSnackbar(

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/FollowAccount.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/FollowAccount.kt
@@ -10,12 +10,14 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class FollowAccount(
     private val externalScope: CoroutineScope,
     private val showSnackbar: ShowSnackbar,
     private val accountRepository: AccountRepository,
+    private val relationshipRepository: RelationshipRepository,
     private val socialDatabase: SocialDatabase,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -32,7 +34,8 @@ class FollowAccount(
                 socialDatabase.accountsDao().updateFollowingCount(loggedInUserAccountId, 1)
                 socialDatabase.relationshipsDao().updateFollowing(accountId, true)
             }
-            accountRepository.followAccount(accountId)
+            val relationship = accountRepository.followAccount(accountId)
+            relationshipRepository.insert(relationship)
         } catch (e: Exception) {
             socialDatabase.withTransaction {
                 socialDatabase.accountsDao().updateFollowingCount(loggedInUserAccountId, -1)

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/MuteAccount.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/MuteAccount.kt
@@ -9,12 +9,14 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class MuteAccount(
     private val externalScope: CoroutineScope,
     private val showSnackbar: ShowSnackbar,
     private val accountRepository: AccountRepository,
+    private val relationshipRepository: RelationshipRepository,
     private val socialDatabase: SocialDatabase,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -29,7 +31,8 @@ class MuteAccount(
                 socialDatabase.localTimelineDao().removePostsFromAccount(accountId)
                 socialDatabase.federatedTimelineDao().removePostsFromAccount(accountId)
                 socialDatabase.relationshipsDao().updateMuted(accountId, true)
-                accountRepository.muteAccount(accountId)
+                val relationship = accountRepository.muteAccount(accountId)
+                relationshipRepository.insert(relationship)
             } catch (e: Exception) {
                 socialDatabase.relationshipsDao().updateMuted(accountId, false)
                 showSnackbar(

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/UnblockAccount.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/UnblockAccount.kt
@@ -9,12 +9,14 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class UnblockAccount(
     private val externalScope: CoroutineScope,
     private val showSnackbar: ShowSnackbar,
     private val accountRepository: AccountRepository,
+    private val relationshipRepository: RelationshipRepository,
     private val socialDatabase: SocialDatabase,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -26,7 +28,8 @@ class UnblockAccount(
         externalScope.async(dispatcherIo) {
             try {
                 socialDatabase.relationshipsDao().updateBlocked(accountId, false)
-                accountRepository.unblockAccount(accountId)
+                val relationship = accountRepository.unblockAccount(accountId)
+                relationshipRepository.insert(relationship)
             } catch (e: Exception) {
                 socialDatabase.relationshipsDao().updateBlocked(accountId, true)
                 showSnackbar(

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/UnfollowAccount.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/UnfollowAccount.kt
@@ -11,12 +11,14 @@ import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.database.model.statusCollections.HomeTimelineStatus
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class UnfollowAccount(
     private val externalScope: CoroutineScope,
     private val showSnackbar: ShowSnackbar,
     private val accountRepository: AccountRepository,
+    private val relationshipRepository: RelationshipRepository,
     private val socialDatabase: SocialDatabase,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -36,7 +38,8 @@ class UnfollowAccount(
                 socialDatabase.accountsDao().updateFollowingCount(loggedInUserAccountId, -1)
                 socialDatabase.relationshipsDao().updateFollowing(accountId, false)
             }
-            accountRepository.unfollowAccount(accountId)
+            val relationship = accountRepository.unfollowAccount(accountId)
+            relationshipRepository.insert(relationship)
         } catch (e: Exception) {
             socialDatabase.withTransaction {
                 timelinePosts?.let { socialDatabase.homeTimelineDao().insertAll(it) }

--- a/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/UnmuteAccount.kt
+++ b/core/usecase/mastodon/src/main/java/org/mozilla/social/core/usecase/mastodon/account/UnmuteAccount.kt
@@ -9,12 +9,14 @@ import org.mozilla.social.common.utils.StringFactory
 import org.mozilla.social.core.database.SocialDatabase
 import org.mozilla.social.core.navigation.usecases.ShowSnackbar
 import org.mozilla.social.core.repository.mastodon.AccountRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.usecase.mastodon.R
 
 class UnmuteAccount(
     private val externalScope: CoroutineScope,
     private val showSnackbar: ShowSnackbar,
     private val accountRepository: AccountRepository,
+    private val relationshipRepository: RelationshipRepository,
     private val socialDatabase: SocialDatabase,
     private val dispatcherIo: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -26,7 +28,8 @@ class UnmuteAccount(
         externalScope.async(dispatcherIo) {
             try {
                 socialDatabase.relationshipsDao().updateMuted(accountId, false)
-                accountRepository.unmuteAccount(accountId)
+                val relationship = accountRepository.unmuteAccount(accountId)
+                relationshipRepository.insert(relationship)
             } catch (e: Exception) {
                 socialDatabase.relationshipsDao().updateMuted(accountId, true)
                 showSnackbar(

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/BaseUseCaseTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/BaseUseCaseTest.kt
@@ -30,6 +30,7 @@ import org.mozilla.social.core.repository.mastodon.InstanceRepository
 import org.mozilla.social.core.repository.mastodon.MediaRepository
 import org.mozilla.social.core.repository.mastodon.OauthRepository
 import org.mozilla.social.core.repository.mastodon.PollRepository
+import org.mozilla.social.core.repository.mastodon.RelationshipRepository
 import org.mozilla.social.core.repository.mastodon.ReportRepository
 import org.mozilla.social.core.repository.mastodon.SearchRepository
 import org.mozilla.social.core.repository.mastodon.StatusRepository
@@ -45,6 +46,7 @@ open class BaseUseCaseTest {
     protected val instanceRepository = mockk<InstanceRepository>(relaxed = true)
     protected val mediaRepository = mockk<MediaRepository>(relaxed = true)
     protected val oauthRepository = mockk<OauthRepository>(relaxed = true)
+    protected val relationshipRepository = mockk<RelationshipRepository>(relaxed = true)
     protected val reportRepository = mockk<ReportRepository>(relaxed = true)
     protected val searchRepository = mockk<SearchRepository>(relaxed = true)
     protected val statusRepository = mockk<StatusRepository>(relaxed = true)

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/BlockAccountTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/BlockAccountTest.kt
@@ -15,6 +15,7 @@ class BlockAccountTest : BaseUseCaseTest() {
                 externalScope = TestScope(testDispatcher),
                 showSnackbar = showSnackbar,
                 accountRepository = accountRepository,
+                relationshipRepository = relationshipRepository,
                 socialDatabase = socialDatabase,
                 dispatcherIo = testDispatcher,
             )

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/FollowAccountTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/FollowAccountTest.kt
@@ -19,6 +19,7 @@ class FollowAccountTest : BaseUseCaseTest() {
                 externalScope = TestScope(testDispatcher),
                 showSnackbar = showSnackbar,
                 accountRepository = accountRepository,
+                relationshipRepository = relationshipRepository,
                 socialDatabase = socialDatabase,
                 dispatcherIo = testDispatcher,
             )

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/MuteAccountTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/MuteAccountTest.kt
@@ -15,6 +15,7 @@ class MuteAccountTest : BaseUseCaseTest() {
                 externalScope = TestScope(testDispatcher),
                 showSnackbar = showSnackbar,
                 accountRepository = accountRepository,
+                relationshipRepository = relationshipRepository,
                 socialDatabase = socialDatabase,
                 dispatcherIo = testDispatcher,
             )

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/UnblockAccountTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/UnblockAccountTest.kt
@@ -15,6 +15,7 @@ class UnblockAccountTest : BaseUseCaseTest() {
                 externalScope = TestScope(testDispatcher),
                 showSnackbar = showSnackbar,
                 accountRepository = accountRepository,
+                relationshipRepository = relationshipRepository,
                 socialDatabase = socialDatabase,
                 dispatcherIo = testDispatcher,
             )

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/UnfollowAccountTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/UnfollowAccountTest.kt
@@ -20,6 +20,7 @@ class UnfollowAccountTest : BaseUseCaseTest() {
                 externalScope = TestScope(testDispatcher),
                 showSnackbar = showSnackbar,
                 accountRepository = accountRepository,
+                relationshipRepository = relationshipRepository,
                 socialDatabase = socialDatabase,
                 dispatcherIo = testDispatcher,
             )

--- a/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/UnmuteAccountTest.kt
+++ b/core/usecase/mastodon/src/test/java/org/mozilla/social/core/usecase/mastodon/account/UnmuteAccountTest.kt
@@ -15,6 +15,7 @@ class UnmuteAccountTest : BaseUseCaseTest() {
                 externalScope = TestScope(testDispatcher),
                 showSnackbar = showSnackbar,
                 accountRepository = accountRepository,
+                relationshipRepository = relationshipRepository,
                 socialDatabase = socialDatabase,
                 dispatcherIo = testDispatcher,
             )


### PR DESCRIPTION
For network calls like block, mute, and follow, mastodon returns the updated relationship object.  I'm just inserting those returned objects into the database in the use cases to fix any discrepancies that occur after updating a relationship.  For example, when you block someone, mastodon will also unfollow that person for you.  