### PR TITLE
Fixing blank screen when opening app

### DIFF
--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -95,7 +95,7 @@ class AppState(
     init {
         coroutineScope.launch(Dispatchers.Main) {
             navigationEventFlow().collectLatest {
-                Timber.d("consuming event $it")
+                Timber.d("NAVIGATION consuming event $it")
                 when (it) {
                     is Event.NavigateToDestination -> {
                         navigate(it.destination)

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/EventRelay.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/EventRelay.kt
@@ -6,7 +6,10 @@ import org.mozilla.social.common.utils.StringFactory
 import timber.log.Timber
 
 class EventRelay {
-    private val _navigationEvents = MutableSharedFlow<Event>(extraBufferCapacity = 10)
+    private val _navigationEvents = MutableSharedFlow<Event>(
+        replay = 1,
+        extraBufferCapacity = 10,
+    )
     val navigationEvents: SharedFlow<Event>
         get() = _navigationEvents
 


### PR DESCRIPTION
I've been getting a bug when running the app on my phone where the initial navigation doesn't happen.  The event tries to emit, but is never collected.  I think the event might be emitting before collection start sometimes in a race condition.  

- Adding replay = 1 to navigation events