### PR TITLE
Fixed startup crash on our release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -61,3 +61,7 @@
 -keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite* {
    <fields>;
 }
+
+-keepclassmembers class * implements android.os.Parcelable {
+        public static final ** CREATOR;
+}


### PR DESCRIPTION
We're getting a crash on our release builds related to the parcelization of the NavBackStackEntryState and the CREATOR object being obfuscated out of existence, so we need a rule to prevent it.