### PR TITLE
Changing new post submission time text

### DIFF
--- a/core/common/src/main/java/org/mozilla/social/common/utils/DateTimeExtensions.kt
+++ b/core/common/src/main/java/org/mozilla/social/common/utils/DateTimeExtensions.kt
@@ -12,11 +12,7 @@ fun Instant.timeSinceNow(): StringFactory {
 
     return when {
         durationSince.inWholeSeconds < 60 ->
-            StringFactory.quantityResource(
-                R.plurals.seconds_ago,
-                durationSince.inWholeSeconds.toInt(),
-                durationSince.inWholeSeconds.toInt(),
-            )
+            StringFactory.resource(R.string.just_now)
         durationSince.inWholeMinutes < 60 ->
             StringFactory.quantityResource(
                 R.plurals.minutes_ago,

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
         <item quantity="one">%d day left</item>
         <item quantity="other">%d days left</item>
     </plurals>
+    <string name="just_now">just now</string>
 </resources>


### PR DESCRIPTION
For posts less than a minute old, the submission time text will be "just now" instead of "0 seconds ago" or "-1 seconds ago"