### PR TITLE
Fixing issue with null meta data

### DIFF
--- a/core/database/src/main/java/org/mozilla/social/core/database/model/DatabaseAttachment.kt
+++ b/core/database/src/main/java/org/mozilla/social/core/database/model/DatabaseAttachment.kt
@@ -57,7 +57,7 @@ sealed class DatabaseAttachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : DatabaseAttachment() {
         @Serializable
         data class Meta(
@@ -85,7 +85,7 @@ sealed class DatabaseAttachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : DatabaseAttachment() {
         @Serializable
         data class Meta(
@@ -117,7 +117,7 @@ sealed class DatabaseAttachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : DatabaseAttachment() {
         @Serializable
         data class Meta(
@@ -147,7 +147,7 @@ sealed class DatabaseAttachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : DatabaseAttachment() {
         @Serializable
         data class Meta(

--- a/core/model/src/main/java/org/mozilla/social/core/model/Attachment.kt
+++ b/core/model/src/main/java/org/mozilla/social/core/model/Attachment.kt
@@ -53,7 +53,7 @@ sealed class Attachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : Attachment() {
         data class Meta(
             val focalPoint: FocalPoint? = null,
@@ -78,7 +78,7 @@ sealed class Attachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : Attachment() {
         data class Meta(
             val aspectRatio: Float? = null,
@@ -107,7 +107,7 @@ sealed class Attachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : Attachment() {
         data class Meta(
             val aspectRatio: Float? = null,
@@ -134,7 +134,7 @@ sealed class Attachment {
         override val textUrl: String? = null,
         override val description: String? = null,
         override val blurHash: String? = null,
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : Attachment() {
         data class Meta(
             val durationSeconds: Double? = null,

--- a/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/model/NetworkAttachment.kt
+++ b/core/network/mastodon/src/main/java/org/mozilla/social/core/network/mastodon/model/NetworkAttachment.kt
@@ -68,7 +68,7 @@ sealed class NetworkAttachment {
         @SerialName("blurhash")
         override val blurHash: String? = null,
         @SerialName("meta")
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : NetworkAttachment() {
         @Serializable
         data class Meta(
@@ -113,7 +113,7 @@ sealed class NetworkAttachment {
         @SerialName("blurhash")
         override val blurHash: String? = null,
         @SerialName("meta")
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : NetworkAttachment() {
         @Serializable
         data class Meta(
@@ -166,7 +166,7 @@ sealed class NetworkAttachment {
         @SerialName("blurhash")
         override val blurHash: String? = null,
         @SerialName("meta")
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : NetworkAttachment() {
         @Serializable
         data class Meta(
@@ -215,7 +215,7 @@ sealed class NetworkAttachment {
         @SerialName("blurhash")
         override val blurHash: String? = null,
         @SerialName("meta")
-        val meta: Meta = Meta(),
+        val meta: Meta? = null,
     ) : NetworkAttachment() {
         @Serializable
         data class Meta(

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/DatabaseToExternal.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/DatabaseToExternal.kt
@@ -152,7 +152,7 @@ fun DatabaseAttachment.toExternalModel(): Attachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is DatabaseAttachment.Gifv ->
             Attachment.Gifv(
@@ -163,7 +163,7 @@ fun DatabaseAttachment.toExternalModel(): Attachment =
                 previewRemoteUrl = previewRemoteUrl,
                 textUrl = textUrl,
                 description = description,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is DatabaseAttachment.Video ->
             Attachment.Video(
@@ -175,7 +175,7 @@ fun DatabaseAttachment.toExternalModel(): Attachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is DatabaseAttachment.Audio ->
             Attachment.Audio(
@@ -187,7 +187,7 @@ fun DatabaseAttachment.toExternalModel(): Attachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is DatabaseAttachment.Unknown ->
             Attachment.Unknown(

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/ExternalToDatabase.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/ExternalToDatabase.kt
@@ -82,7 +82,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toDatabaseModel(),
+                meta = meta?.toDatabaseModel(),
             )
 
         is Attachment.Gifv ->
@@ -94,7 +94,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
                 previewRemoteUrl = previewRemoteUrl,
                 textUrl = textUrl,
                 description = description,
-                meta = meta.toDatabaseModel(),
+                meta = meta?.toDatabaseModel(),
             )
 
         is Attachment.Video ->
@@ -107,7 +107,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toDatabaseModel(),
+                meta = meta?.toDatabaseModel(),
             )
 
         is Attachment.Audio ->
@@ -120,7 +120,7 @@ fun Attachment.toDatabaseModel(): DatabaseAttachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toDatabaseModel(),
+                meta = meta?.toDatabaseModel(),
             )
 
         is Attachment.Unknown ->

--- a/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/NetworkToExternal.kt
+++ b/core/repository/mastodon/src/main/java/org/mozilla/social/core/repository/mastodon/model/status/NetworkToExternal.kt
@@ -112,7 +112,7 @@ fun NetworkAttachment.toExternalModel(): Attachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is NetworkAttachment.Gifv ->
             Attachment.Gifv(
@@ -123,7 +123,7 @@ fun NetworkAttachment.toExternalModel(): Attachment =
                 previewRemoteUrl = previewRemoteUrl,
                 textUrl = textUrl,
                 description = description,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is NetworkAttachment.Video ->
             Attachment.Video(
@@ -135,7 +135,7 @@ fun NetworkAttachment.toExternalModel(): Attachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is NetworkAttachment.Audio ->
             Attachment.Audio(
@@ -147,7 +147,7 @@ fun NetworkAttachment.toExternalModel(): Attachment =
                 textUrl = textUrl,
                 description = description,
                 blurHash = blurHash,
-                meta = meta.toExternalModel(),
+                meta = meta?.toExternalModel(),
             )
         is NetworkAttachment.Unknown ->
             Attachment.Unknown(

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/media/MediaDisplay.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/media/MediaDisplay.kt
@@ -60,13 +60,13 @@ private fun SingleAttachment(attachment: Attachment) {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .aspectRatio(attachment.meta.calculateAspectRatio()),
+                        .aspectRatio(attachment.meta?.calculateAspectRatio() ?: 1f),
                 attachment = attachment,
             )
         }
         is Attachment.Gifv -> {
             val aspectRatio by remember {
-                mutableFloatStateOf(attachment.meta.calculateAspectRatio())
+                mutableFloatStateOf(attachment.meta?.calculateAspectRatio() ?: 1f)
             }
             attachment.url?.toUri()?.let {
                 VideoPlayer(
@@ -77,7 +77,7 @@ private fun SingleAttachment(attachment: Attachment) {
         }
         is Attachment.Video -> {
             val aspectRatio by remember {
-                mutableFloatStateOf(attachment.meta.calculateAspectRatio())
+                mutableFloatStateOf(attachment.meta?.calculateAspectRatio() ?: 1f)
             }
             attachment.url?.toUri()?.let {
                 VideoPlayer(


### PR DESCRIPTION
I ran across a server that gave me a null value for video metadata.  It's not supposed to be null according to the mastodon api docs, but there's no harm in making it nullable