### PR TITLE
Adding developer options screen

### DIFF
--- a/app/src/main/java/org/mozilla/social/ui/AppState.kt
+++ b/app/src/main/java/org/mozilla/social/ui/AppState.kt
@@ -43,6 +43,7 @@ import org.mozilla.social.core.navigation.SettingsNavigationDestination.AboutSet
 import org.mozilla.social.core.navigation.SettingsNavigationDestination.AccountSettings.navigateToAccountSettings
 import org.mozilla.social.core.navigation.SettingsNavigationDestination.BlockedUsersSettings.navigateToBlockedUsers
 import org.mozilla.social.core.navigation.SettingsNavigationDestination.ContentPreferencesSettings.navigateToContentPreferencesSettings
+import org.mozilla.social.core.navigation.SettingsNavigationDestination.DeveloperOptions.navigateToDeveloperOptions
 import org.mozilla.social.core.navigation.SettingsNavigationDestination.MainSettings.navigateToMainSettings
 import org.mozilla.social.core.navigation.SettingsNavigationDestination.MutedUsersSettings.navigateToMutedUsers
 import org.mozilla.social.core.navigation.SettingsNavigationDestination.OpenSourceLicensesSettings.navigateToOpenSourceSettings
@@ -288,6 +289,10 @@ class AppState(
 
             SettingsNavigationDestination.OpenSourceLicensesSettings -> {
                 mainNavController.navigateToOpenSourceSettings()
+            }
+
+            SettingsNavigationDestination.DeveloperOptions -> {
+                mainNavController.navigateToDeveloperOptions()
             }
         }
     }

--- a/core/navigation/src/main/java/org/mozilla/social/core/navigation/SettingsNavigationDestination.kt
+++ b/core/navigation/src/main/java/org/mozilla/social/core/navigation/SettingsNavigationDestination.kt
@@ -64,4 +64,12 @@ sealed class SettingsNavigationDestination(val route: String) {
             navigate(route = route)
         }
     }
+
+    data object DeveloperOptions : SettingsNavigationDestination(
+        route = "developerOptions",
+    ) {
+        fun NavController.navigateToDeveloperOptions() {
+            navigate(route = route)
+        }
+    }
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 android {
     namespace = "org.mozilla.social.feature.settings"
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsInteractions.kt
@@ -2,4 +2,9 @@ package org.mozilla.social.feature.settings
 
 interface SettingsInteractions {
     fun onScreenViewed() = Unit
+    fun onAboutClicked() = Unit
+    fun onAccountClicked() = Unit
+    fun onContentPreferencesClicked() = Unit
+    fun onPrivacyClicked() = Unit
+    fun onDeveloperOptionsClicked() = Unit
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsModule.kt
@@ -29,7 +29,7 @@ val settingsModule =
             mastodonUsecaseModule,
         )
 
-        viewModel { _ -> SettingsViewModel(get(), get(), get()) }
+        viewModelOf(::SettingsViewModel)
         viewModelOf(::AccountSettingsViewModel)
         viewModelOf(::PrivacySettingsViewModel)
         viewModelOf(::AboutSettingsViewModel)

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsNavigation.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsNavigation.kt
@@ -10,6 +10,7 @@ import org.mozilla.social.feature.settings.account.AccountSettingsScreen
 import org.mozilla.social.feature.settings.contentpreferences.ContentPreferencesSettingsScreen
 import org.mozilla.social.feature.settings.contentpreferences.blockedusers.BlockedUsersSettingsScreen
 import org.mozilla.social.feature.settings.contentpreferences.mutedusers.MutedUsersSettingsScreen
+import org.mozilla.social.feature.settings.developer.DeveloperOptionsScreen
 import org.mozilla.social.feature.settings.licenses.OpenSourceLicensesScreen
 import org.mozilla.social.feature.settings.privacy.PrivacySettingsScreen
 
@@ -26,6 +27,7 @@ fun NavGraphBuilder.settingsFlow() {
         privacySettingsScreen()
         aboutSettingsScreen()
         openSourceLicensesScreen()
+        developerOptionsScreen()
     }
 }
 
@@ -74,5 +76,11 @@ fun NavGraphBuilder.aboutSettingsScreen() {
 fun NavGraphBuilder.openSourceLicensesScreen() {
     composable(route = SettingsNavigationDestination.OpenSourceLicensesSettings.route) {
         OpenSourceLicensesScreen()
+    }
+}
+
+fun NavGraphBuilder.developerOptionsScreen() {
+    composable(route = SettingsNavigationDestination.DeveloperOptions.route) {
+        DeveloperOptionsScreen()
     }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsScreen.kt
@@ -3,7 +3,6 @@ package org.mozilla.social.feature.settings
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -11,7 +10,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
 import org.mozilla.social.common.Version
 import org.mozilla.social.core.designsystem.icon.MoSoIcons
@@ -22,21 +20,17 @@ import org.mozilla.social.feature.settings.ui.SettingsColumn
 import org.mozilla.social.feature.settings.ui.SettingsSection
 
 @Composable
-fun SettingsScreen(viewModel: SettingsViewModel = koinViewModel()) {
+fun SettingsScreen(
+    viewModel: SettingsViewModel = koinViewModel()
+) {
     SettingsScreen(
-        onAccountClicked = viewModel::onAccountClicked,
-        onContentPreferencesClicked = viewModel::onContentPreferencesClicked,
-        onPrivacyClicked = viewModel::onPrivacyClicked,
-        onAboutClicked = viewModel::onAboutClicked,
+        settingsInteractions = viewModel
     )
 }
 
 @Composable
 fun SettingsScreen(
-    onAccountClicked: () -> Unit,
-    onContentPreferencesClicked: () -> Unit,
-    onPrivacyClicked: () -> Unit,
-    onAboutClicked: () -> Unit,
+    settingsInteractions: SettingsInteractions,
 ) {
     MoSoSurface {
         Box(
@@ -50,23 +44,31 @@ fun SettingsScreen(
                 SettingsSection(
                     title = stringResource(id = R.string.account_settings_title),
                     iconPainter = MoSoIcons.identificationCard(),
-                    onClick = onAccountClicked,
+                    onClick = settingsInteractions::onAccountClicked,
                 )
                 SettingsSection(
                     title = stringResource(id = R.string.content_preferences_title),
                     iconPainter = MoSoIcons.listChecks(),
-                    onClick = onContentPreferencesClicked,
+                    onClick = settingsInteractions::onContentPreferencesClicked,
                 )
                 SettingsSection(
                     title = stringResource(id = R.string.privacy_settings_title),
                     iconPainter = MoSoIcons.lockKey(),
-                    onClick = onPrivacyClicked,
+                    onClick = settingsInteractions::onPrivacyClicked,
                 )
                 SettingsSection(
                     title = stringResource(id = R.string.about_settings_title),
                     iconPainter = MoSoIcons.info(),
-                    onClick = onAboutClicked,
+                    onClick = settingsInteractions::onAboutClicked,
                 )
+
+                if (BuildConfig.DEBUG) {
+                    SettingsSection(
+                        title = stringResource(id = R.string.developer_options_title),
+                        iconPainter = MoSoIcons.robot(),
+                        onClick = settingsInteractions::onDeveloperOptionsClicked,
+                    )
+                }
 
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
@@ -86,10 +88,7 @@ private fun SettingsScreenPreview() {
         modules = listOf(navigationModule)
     ) {
         SettingsScreen(
-            onAboutClicked = {},
-            onContentPreferencesClicked = {},
-            onPrivacyClicked = {},
-            onAccountClicked = {},
+            settingsInteractions = object : SettingsInteractions {}
         )
     }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsViewModel.kt
@@ -1,47 +1,34 @@
 package org.mozilla.social.feature.settings
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import org.mozilla.social.core.analytics.Analytics
 import org.mozilla.social.core.analytics.AnalyticsIdentifiers
-import org.mozilla.social.core.datastore.AppPreferencesDatastore
 import org.mozilla.social.core.navigation.SettingsNavigationDestination
 import org.mozilla.social.core.navigation.usecases.NavigateTo
 
 class SettingsViewModel(
     private val analytics: Analytics,
-    private val appPreferencesDatastore: AppPreferencesDatastore,
     private val navigateTo: NavigateTo,
 ) : ViewModel(), SettingsInteractions {
-    private val _isAnalyticsToggledOn: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    var isAnalyticsToggledOn = _isAnalyticsToggledOn.asStateFlow()
 
-    init {
-        viewModelScope.launch {
-            appPreferencesDatastore.allowAnalytics.collectLatest { enabled ->
-                _isAnalyticsToggledOn.value = enabled
-            }
-        }
-    }
-
-    fun onAboutClicked() {
+    override fun onAboutClicked() {
         navigateTo(SettingsNavigationDestination.AboutSettings)
     }
 
-    fun onAccountClicked() {
+    override fun onAccountClicked() {
         navigateTo(SettingsNavigationDestination.AccountSettings)
     }
 
-    fun onContentPreferencesClicked() {
+    override fun onContentPreferencesClicked() {
         navigateTo(SettingsNavigationDestination.ContentPreferencesSettings)
     }
 
-    fun onPrivacyClicked() {
+    override fun onPrivacyClicked() {
         navigateTo(SettingsNavigationDestination.PrivacySettings)
+    }
+
+    override fun onDeveloperOptionsClicked() {
+        navigateTo(SettingsNavigationDestination.DeveloperOptions)
     }
 
     override fun onScreenViewed() {

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/developer/DeveloperOptionsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/developer/DeveloperOptionsScreen.kt
@@ -1,0 +1,26 @@
+package org.mozilla.social.feature.settings.developer
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.mozilla.social.core.ui.common.MoSoSurface
+import org.mozilla.social.core.ui.common.appbar.MoSoCloseableTopAppBar
+import org.mozilla.social.feature.settings.R
+
+@Composable
+fun DeveloperOptionsScreen() {
+    MoSoSurface(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding(),
+    ) {
+        Column {
+            MoSoCloseableTopAppBar(
+                title = stringResource(id = R.string.developer_options_title)
+            )
+        }
+    }
+}

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="privacy_settings_title">Privacy</string>
     <string name="about_settings_title">About</string>
     <string name="licenses_settings_title">Licenses</string>
+    <string name="developer_options_title">Developer Options</string>
     <string name="server_community_rules">Server/Community Rules</string>
     <string name="administered_by">Administered by</string>
     <string name="decentralized_social_media_powered_by_mastodon">Decentralized social media powered by Mastodon</string>

--- a/feature/settings/src/test/kotlin/org/mozilla/social/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/org/mozilla/social/feature/settings/SettingsViewModelTest.kt
@@ -3,11 +3,11 @@ package org.mozilla.social.feature.settings
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import org.mozilla.social.core.analytics.Analytics
-import org.mozilla.social.core.datastore.AppPreferencesDatastore
 import org.mozilla.social.core.navigation.SettingsNavigationDestination
 import org.mozilla.social.core.navigation.usecases.NavigateTo
 import kotlin.test.BeforeTest
@@ -17,15 +17,14 @@ class SettingsViewModelTest {
 
     private val navigateTo: NavigateTo = mockk(relaxed = true)
     private val analytics: Analytics = mockk(relaxed = true)
-    private val appPreferencesDatastore: AppPreferencesDatastore = mockk()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         objUnderTest =
             SettingsViewModel(
                 analytics = analytics,
-                appPreferencesDatastore = appPreferencesDatastore,
                 navigateTo = navigateTo,
             )
     }


### PR DESCRIPTION
I pulled the changes out of https://github.com/MozillaSocial/mozilla-social-android/pull/353

- Adding a developer options screen to settings that only shows in debug mode