### PR TITLE
Settings interface / compose preview fixes

### DIFF
--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsInteractions.kt
@@ -1,10 +1,10 @@
 package org.mozilla.social.feature.settings
 
 interface SettingsInteractions {
-    fun onScreenViewed() = Unit
-    fun onAboutClicked() = Unit
-    fun onAccountClicked() = Unit
-    fun onContentPreferencesClicked() = Unit
-    fun onPrivacyClicked() = Unit
-    fun onDeveloperOptionsClicked() = Unit
+    fun onScreenViewed()
+    fun onAboutClicked()
+    fun onAccountClicked()
+    fun onContentPreferencesClicked()
+    fun onPrivacyClicked()
+    fun onDeveloperOptionsClicked()
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/SettingsScreen.kt
@@ -88,7 +88,14 @@ private fun SettingsScreenPreview() {
         modules = listOf(navigationModule)
     ) {
         SettingsScreen(
-            settingsInteractions = object : SettingsInteractions {}
+            settingsInteractions = object : SettingsInteractions {
+                override fun onScreenViewed() = Unit
+                override fun onAboutClicked() = Unit
+                override fun onAccountClicked() = Unit
+                override fun onContentPreferencesClicked() = Unit
+                override fun onPrivacyClicked() = Unit
+                override fun onDeveloperOptionsClicked() = Unit
+            }
         )
     }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutInteractions.kt
@@ -1,6 +1,7 @@
 package org.mozilla.social.feature.settings.about
 
 interface AboutInteractions {
+    fun onScreenViewed()
     fun onOpenSourceLicensesClicked()
     fun onRetryClicked()
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
@@ -199,6 +199,7 @@ fun AboutSettingsScreenPreview() {
     ) {
         AboutSettingsScreen(
             aboutInteractions = object : AboutInteractions {
+                override fun onScreenViewed() = Unit
                 override fun onOpenSourceLicensesClicked() = Unit
                 override fun onRetryClicked() = Unit
             },

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsScreen.kt
@@ -44,7 +44,7 @@ import org.mozilla.social.core.ui.htmlcontent.HtmlContentInteractions
 import org.mozilla.social.feature.settings.R
 
 @Composable
-fun AboutSettingsScreen(
+internal fun AboutSettingsScreen(
     aboutSettingsViewModel: AboutSettingsViewModel = koinViewModel()
 ) {
     val aboutSettings: Resource<AboutSettings> by aboutSettingsViewModel.aboutSettings.collectAsStateWithLifecycle()
@@ -61,7 +61,7 @@ fun AboutSettingsScreen(
 }
 
 @Composable
-fun AboutSettingsScreen(
+private fun AboutSettingsScreen(
     aboutSettingsResource: Resource<AboutSettings>,
     htmlContentInteractions: HtmlContentInteractions,
     aboutInteractions: AboutInteractions,

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/about/AboutSettingsViewModel.kt
@@ -30,7 +30,6 @@ class AboutSettingsViewModel(
     private val defaultHtmlInteractions: DefaultHtmlInteractions,
 ) : ViewModel(),
     AboutInteractions,
-    SettingsInteractions,
     HtmlContentInteractions by defaultHtmlInteractions {
 
     private val userAccountId: String = getLoggedInUserAccountId()

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsInteractions.kt
@@ -1,0 +1,7 @@
+package org.mozilla.social.feature.settings.account
+
+interface AccountSettingsInteractions {
+    fun onScreenViewed()
+    fun onLogoutClicked()
+    fun onManageAccountClicked()
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsScreen.kt
@@ -37,7 +37,7 @@ import org.mozilla.social.feature.settings.ui.SettingsColumn
 import org.mozilla.social.feature.settings.ui.SettingsSection
 
 @Composable
-fun AccountSettingsScreen(
+internal fun AccountSettingsScreen(
     viewModel: AccountSettingsViewModel = koinViewModel()
 ) {
     val userHeader by viewModel.userHeader.collectAsStateWithLifecycle(

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/account/AccountSettingsViewModel.kt
@@ -27,7 +27,7 @@ class AccountSettingsViewModel(
     private val getDomain: GetDomain,
     getLoggedInUserAccountId: GetLoggedInUserAccountId,
     accountRepository: AccountRepository,
-) : ViewModel(), SettingsInteractions {
+) : ViewModel(), AccountSettingsInteractions {
 
     private val userAccountId: String = getLoggedInUserAccountId()
     private val domain = getDomain().stateIn(viewModelScope, SharingStarted.Eagerly, null)
@@ -41,7 +41,7 @@ class AccountSettingsViewModel(
         }
 
 
-    fun onLogoutClicked() {
+    override fun onLogoutClicked() {
         logoutClickedAnalytics()
         viewModelScope.launch {
             logout()
@@ -55,7 +55,7 @@ class AccountSettingsViewModel(
         )
     }
 
-    fun onManageAccountClicked() {
+    override fun onManageAccountClicked() {
         domain.value?.let { openLink("$it/settings/profile") }
     }
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/ContentPreferencesSettingsInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/ContentPreferencesSettingsInteractions.kt
@@ -1,0 +1,5 @@
+package org.mozilla.social.feature.settings.contentpreferences
+
+interface ContentPreferencesSettingsInteractions {
+    fun onScreenViewed()
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/ContentPreferencesSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/ContentPreferencesSettingsScreen.kt
@@ -11,7 +11,7 @@ import org.mozilla.social.feature.settings.ui.SettingsColumn
 import org.mozilla.social.feature.settings.ui.SettingsSection
 
 @Composable
-fun ContentPreferencesSettingsScreen(viewModel: ContentPreferencesSettingsViewModel = koinViewModel()) {
+internal fun ContentPreferencesSettingsScreen(viewModel: ContentPreferencesSettingsViewModel = koinViewModel()) {
     ContentPreferencesSettingsScreen(
         onBlockedUsersClicked = viewModel::onBlockedUsersClicked,
         onMutedUsersClicked = viewModel::onMutedUsersClicked,

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/ContentPreferencesSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/ContentPreferencesSettingsViewModel.kt
@@ -12,7 +12,7 @@ class ContentPreferencesSettingsViewModel(
     private val navigateTo: NavigateTo,
     private val analytics: Analytics,
     getLoggedInUserAccountId: GetLoggedInUserAccountId,
-) : ViewModel(), SettingsInteractions {
+) : ViewModel(), ContentPreferencesSettingsInteractions {
 
     private val userAccountId: String = getLoggedInUserAccountId()
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedButtonState.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedButtonState.kt
@@ -1,0 +1,31 @@
+package org.mozilla.social.feature.settings.contentpreferences.blockedusers
+
+import androidx.annotation.StringRes
+import org.mozilla.social.common.utils.StringFactory
+import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableButtonState
+import org.mozilla.social.core.ui.common.button.MoSoButtonPrimaryDefaults
+import org.mozilla.social.core.ui.common.button.MoSoButtonSecondaryDefaults
+import org.mozilla.social.core.ui.common.button.MoSoButtonTheme
+import org.mozilla.social.feature.settings.R
+
+/**
+ * Blocked button state is an implementation of [ToggleableButtonState] which encapsulates the
+ * different states a user can be in, and what the text on the button should be for those states
+ */
+sealed class BlockedButtonState(
+    @get:StringRes override val text: Int,
+    override val confirmationText: StringFactory? = null,
+    override val theme: MoSoButtonTheme,
+) : ToggleableButtonState {
+    data object Blocked : BlockedButtonState(
+        text = R.string.unblock,
+        theme = MoSoButtonSecondaryDefaults,
+    ) {
+        override val confirmationText: StringFactory? = null
+    }
+
+    data class Unblocked(override val confirmationText: StringFactory?) : BlockedButtonState(
+        text = R.string.block,
+        theme = MoSoButtonPrimaryDefaults,
+    )
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersInteractions.kt
@@ -1,0 +1,5 @@
+package org.mozilla.social.feature.settings.contentpreferences.blockedusers
+
+interface BlockedUsersInteractions {
+    fun onScreenViewed()
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersInteractions.kt
@@ -2,4 +2,6 @@ package org.mozilla.social.feature.settings.contentpreferences.blockedusers
 
 interface BlockedUsersInteractions {
     fun onScreenViewed()
+    fun onButtonClicked(accountId: String, buttonState: BlockedButtonState)
+    fun onAccountClicked(accountId: String)
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersSettingsScreen.kt
@@ -1,25 +1,25 @@
 package org.mozilla.social.feature.settings.contentpreferences.blockedusers
 
-import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import org.koin.androidx.compose.koinViewModel
-import org.mozilla.social.common.utils.StringFactory
+import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.ui.common.MoSoSurface
 import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableAccountList
 import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableAccountListItemState
-import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableButtonState
-import org.mozilla.social.core.ui.common.button.MoSoButtonPrimaryDefaults
-import org.mozilla.social.core.ui.common.button.MoSoButtonSecondaryDefaults
-import org.mozilla.social.core.ui.common.button.MoSoButtonTheme
+import org.mozilla.social.core.ui.common.utils.PreviewTheme
 import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 
 @Composable
-internal fun BlockedUsersSettingsScreen(viewModel: BlockedUsersViewModel = koinViewModel()) {
+internal fun BlockedUsersSettingsScreen(
+    viewModel: BlockedUsersViewModel = koinViewModel()
+) {
     BlockedUsersSettingsScreen(
         pagingData = viewModel.blocks,
         blockedUsersInteractions = viewModel,
@@ -46,24 +46,19 @@ private fun BlockedUsersSettingsScreen(
     }
 }
 
-/**
- * Blocked button state is an implementation of [ToggleableButtonState] which encapsulates the
- * different states a user can be in, and what the text on the button should be for those states
- */
-sealed class BlockedButtonState(
-    @get:StringRes override val text: Int,
-    override val confirmationText: StringFactory? = null,
-    override val theme: MoSoButtonTheme,
-) : ToggleableButtonState {
-    data object Blocked : BlockedButtonState(
-        text = R.string.unblock,
-        theme = MoSoButtonSecondaryDefaults,
+@Preview
+@Composable
+private fun BlockedUsersSettingsScreenPreview() {
+    PreviewTheme(
+        modules = listOf(navigationModule)
     ) {
-        override val confirmationText: StringFactory? = null
+        BlockedUsersSettingsScreen(
+            pagingData = emptyFlow(),
+            blockedUsersInteractions = object : BlockedUsersInteractions {
+                override fun onScreenViewed() = Unit
+                override fun onButtonClicked(accountId: String, buttonState: BlockedButtonState) = Unit
+                override fun onAccountClicked(accountId: String) = Unit
+            }
+        )
     }
-
-    data class Unblocked(override val confirmationText: StringFactory?) : BlockedButtonState(
-        text = R.string.block,
-        theme = MoSoButtonPrimaryDefaults,
-    )
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersSettingsScreen.kt
@@ -19,11 +19,10 @@ import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 
 @Composable
-fun BlockedUsersSettingsScreen(viewModel: BlockedUsersViewModel = koinViewModel()) {
+internal fun BlockedUsersSettingsScreen(viewModel: BlockedUsersViewModel = koinViewModel()) {
     BlockedUsersSettingsScreen(
         pagingData = viewModel.blocks,
-        onAccountClicked = viewModel::onAccountClicked,
-        onButtonClicked = viewModel::onButtonClicked
+        blockedUsersInteractions = viewModel,
     )
 
     LaunchedEffect(Unit) {
@@ -32,17 +31,16 @@ fun BlockedUsersSettingsScreen(viewModel: BlockedUsersViewModel = koinViewModel(
 }
 
 @Composable
-fun BlockedUsersSettingsScreen(
+private fun BlockedUsersSettingsScreen(
     pagingData: Flow<PagingData<ToggleableAccountListItemState<BlockedButtonState>>>,
-    onAccountClicked: (accountId: String) -> Unit,
-    onButtonClicked: (accountId: String, buttonState: BlockedButtonState) -> Unit,
+    blockedUsersInteractions: BlockedUsersInteractions,
 ) {
     MoSoSurface {
         SettingsColumn(title = stringResource(id = R.string.blocked_users_title)) {
             ToggleableAccountList(
                 pagingData = pagingData,
-                onAccountClicked = onAccountClicked,
-                onButtonClicked = onButtonClicked,
+                onAccountClicked = blockedUsersInteractions::onAccountClicked,
+                onButtonClicked = blockedUsersInteractions::onButtonClicked,
             )
         }
     }
@@ -53,7 +51,7 @@ fun BlockedUsersSettingsScreen(
  * different states a user can be in, and what the text on the button should be for those states
  */
 sealed class BlockedButtonState(
-    override @get:StringRes val text: Int,
+    @get:StringRes override val text: Int,
     override val confirmationText: StringFactory? = null,
     override val theme: MoSoButtonTheme,
 ) : ToggleableButtonState {

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
@@ -42,7 +42,7 @@ class BlockedUsersViewModel(
         repository.getBlocksPager(remoteMediator = remoteMediator)
             .map { pagingData -> pagingData.map { blockedUser -> blockedUser.toToggleableState() } }
 
-    fun onButtonClicked(accountId: String, buttonState: BlockedButtonState) {
+    override fun onButtonClicked(accountId: String, buttonState: BlockedButtonState) {
         viewModelScope.launch(Dispatchers.IO) {
             when (buttonState) {
                 is BlockedButtonState.Blocked -> {
@@ -64,7 +64,7 @@ class BlockedUsersViewModel(
         }
     }
 
-    fun onAccountClicked(accountId: String) {
+    override fun onAccountClicked(accountId: String) {
         navigateToAccount(accountId)
     }
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/blockedusers/BlockedUsersViewModel.kt
@@ -33,7 +33,7 @@ class BlockedUsersViewModel(
     private val blockAccount: BlockAccount,
     private val unblockAccount: UnblockAccount,
     private val navigateToAccount: NavigateToAccount,
-) : ViewModel(), SettingsInteractions {
+) : ViewModel(), BlockedUsersInteractions {
 
     private val userAccountId: String = getLoggedInUserAccountId()
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedButtonState.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedButtonState.kt
@@ -1,0 +1,31 @@
+package org.mozilla.social.feature.settings.contentpreferences.mutedusers
+
+import androidx.annotation.StringRes
+import org.mozilla.social.common.utils.StringFactory
+import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableButtonState
+import org.mozilla.social.core.ui.common.button.MoSoButtonPrimaryDefaults
+import org.mozilla.social.core.ui.common.button.MoSoButtonSecondaryDefaults
+import org.mozilla.social.core.ui.common.button.MoSoButtonTheme
+import org.mozilla.social.feature.settings.R
+
+/**
+ * Muted button state is an implementation of [ToggleableButtonState] which encapsulates the
+ * different states a user can be in, and what the text on the button should be for those states
+ */
+sealed class MutedButtonState(
+    @get:StringRes override val text: Int,
+    override val confirmationText: StringFactory? = null,
+    override val theme: MoSoButtonTheme,
+) : ToggleableButtonState {
+    data object Muted : MutedButtonState(
+        text = R.string.unmute,
+        theme = MoSoButtonSecondaryDefaults,
+    ) {
+        override val confirmationText: StringFactory? = null
+    }
+
+    data class Unmuted(override val confirmationText: StringFactory?) : MutedButtonState(
+        text = R.string.mute,
+        theme = MoSoButtonPrimaryDefaults,
+    )
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersInteractions.kt
@@ -2,4 +2,6 @@ package org.mozilla.social.feature.settings.contentpreferences.mutedusers
 
 interface MutedUsersInteractions {
     fun onScreenViewed()
+    fun onButtonClicked(accountId: String, mutedButtonState: MutedButtonState)
+    fun onAccountClicked(accountId: String)
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersInteractions.kt
@@ -1,0 +1,5 @@
+package org.mozilla.social.feature.settings.contentpreferences.mutedusers
+
+interface MutedUsersInteractions {
+    fun onScreenViewed()
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsScreen.kt
@@ -16,7 +16,7 @@ import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 
 @Composable
-fun MutedUsersSettingsScreen(viewModel: MutedUsersSettingsViewModel = koinViewModel()) {
+internal fun MutedUsersSettingsScreen(viewModel: MutedUsersSettingsViewModel = koinViewModel()) {
     MoSoSurface {
         SettingsColumn(title = stringResource(id = R.string.muted_users_title)) {
             ToggleableAccountList(

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsScreen.kt
@@ -1,55 +1,67 @@
 package org.mozilla.social.feature.settings.contentpreferences.mutedusers
 
-import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import org.koin.androidx.compose.koinViewModel
-import org.mozilla.social.common.utils.StringFactory
+import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.ui.common.MoSoSurface
 import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableAccountList
-import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableButtonState
-import org.mozilla.social.core.ui.common.button.MoSoButtonPrimaryDefaults
-import org.mozilla.social.core.ui.common.button.MoSoButtonSecondaryDefaults
-import org.mozilla.social.core.ui.common.button.MoSoButtonTheme
+import org.mozilla.social.core.ui.common.account.toggleablelist.ToggleableAccountListItemState
+import org.mozilla.social.core.ui.common.utils.PreviewTheme
 import org.mozilla.social.feature.settings.R
+import org.mozilla.social.feature.settings.contentpreferences.blockedusers.BlockedButtonState
+import org.mozilla.social.feature.settings.contentpreferences.blockedusers.BlockedUsersInteractions
+import org.mozilla.social.feature.settings.contentpreferences.blockedusers.BlockedUsersSettingsScreen
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 
 @Composable
-internal fun MutedUsersSettingsScreen(viewModel: MutedUsersSettingsViewModel = koinViewModel()) {
-    MoSoSurface {
-        SettingsColumn(title = stringResource(id = R.string.muted_users_title)) {
-            ToggleableAccountList(
-                pagingData = viewModel.mutes,
-                onAccountClicked = viewModel::onAccountClicked,
-                onButtonClicked = viewModel::onButtonClicked
-            )
-        }
-    }
+internal fun MutedUsersSettingsScreen(
+    viewModel: MutedUsersSettingsViewModel = koinViewModel()
+) {
+    MutedUsersSettingsScreen(
+        pagingData = viewModel.mutes,
+        mutedUsersInteractions = viewModel,
+    )
 
     LaunchedEffect(Unit) {
         viewModel.onScreenViewed()
     }
 }
 
-/**
- * Muted button state is an implementation of [ToggleableButtonState] which encapsulates the
- * different states a user can be in, and what the text on the button should be for those states
- */
-sealed class MutedButtonState(
-    @get:StringRes override val text: Int,
-    override val confirmationText: StringFactory? = null,
-    override val theme: MoSoButtonTheme,
-) : ToggleableButtonState {
-    data object Muted : MutedButtonState(
-        text = R.string.unmute,
-        theme = MoSoButtonSecondaryDefaults,
-    ) {
-        override val confirmationText: StringFactory? = null
+@Composable
+private fun MutedUsersSettingsScreen(
+    pagingData: Flow<PagingData<ToggleableAccountListItemState<MutedButtonState>>>,
+    mutedUsersInteractions: MutedUsersInteractions,
+) {
+    MoSoSurface {
+        SettingsColumn(title = stringResource(id = R.string.muted_users_title)) {
+            ToggleableAccountList(
+                pagingData = pagingData,
+                onAccountClicked = mutedUsersInteractions::onAccountClicked,
+                onButtonClicked = mutedUsersInteractions::onButtonClicked
+            )
+        }
     }
+}
 
-    data class Unmuted(override val confirmationText: StringFactory?) : MutedButtonState(
-        text = R.string.mute,
-        theme = MoSoButtonPrimaryDefaults,
-    )
+@Preview
+@Composable
+private fun MutedUsersSettingsScreenPreview() {
+    PreviewTheme(
+        modules = listOf(navigationModule)
+    ) {
+        MutedUsersSettingsScreen(
+            pagingData = emptyFlow(),
+            mutedUsersInteractions = object : MutedUsersInteractions {
+                override fun onScreenViewed() = Unit
+                override fun onButtonClicked(accountId: String, mutedButtonState: MutedButtonState) = Unit
+                override fun onAccountClicked(accountId: String) = Unit
+            }
+        )
+    }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
@@ -33,7 +33,7 @@ class MutedUsersSettingsViewModel(
     private val muteAccount: MuteAccount,
     private val unmuteAccount: UnmuteAccount,
     private val navigateToAccount: NavigateToAccount,
-) : ViewModel(), SettingsInteractions {
+) : ViewModel(), MutedUsersInteractions {
 
     private val userAccountId: String = getLoggedInUserAccountId()
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/contentpreferences/mutedusers/MutedUsersSettingsViewModel.kt
@@ -42,7 +42,7 @@ class MutedUsersSettingsViewModel(
         repository.getMutesPager(remoteMediator)
             .map { pagingData -> pagingData.map { mutedUser -> mutedUser.toToggleableState() } }
 
-    fun onButtonClicked(accountId: String, mutedButtonState: MutedButtonState) {
+    override fun onButtonClicked(accountId: String, mutedButtonState: MutedButtonState) {
         viewModelScope.launch(Dispatchers.IO) {
             when (mutedButtonState) {
                 is MutedButtonState.Muted -> {
@@ -64,7 +64,7 @@ class MutedUsersSettingsViewModel(
         }
     }
 
-    fun onAccountClicked(accountId: String) {
+    override fun onAccountClicked(accountId: String) {
         navigateToAccount(accountId)
     }
 

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsInteractions.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsInteractions.kt
@@ -1,0 +1,5 @@
+package org.mozilla.social.feature.settings.privacy
+
+interface PrivacySettingsInteractions {
+    fun onScreenViewed()
+}

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsScreen.kt
@@ -8,8 +8,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.androidx.compose.koinViewModel
-import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.ui.common.MoSoSurface
+import org.mozilla.social.core.ui.common.utils.PreviewTheme
 import org.mozilla.social.feature.settings.R
 import org.mozilla.social.feature.settings.ui.SettingsColumn
 import org.mozilla.social.feature.settings.ui.SettingsGroup
@@ -30,7 +31,7 @@ fun PrivacySettingsScreen(viewModel: PrivacySettingsViewModel = koinViewModel())
 }
 
 @Composable
-fun PrivacySettingsScreen(
+private fun PrivacySettingsScreen(
     isAnalyticsToggledOn: Boolean,
     toggleAnalyticsSwitch: () -> Unit,
 ) {
@@ -64,7 +65,12 @@ private fun AllowAnalyticsSwitch(
 @Preview
 @Composable
 private fun PrivacySettingsScreenPreview() {
-    MoSoTheme {
-        PrivacySettingsScreen(isAnalyticsToggledOn = true, {})
+    PreviewTheme(
+        modules = listOf(navigationModule)
+    ) {
+        PrivacySettingsScreen(
+            isAnalyticsToggledOn = true,
+            toggleAnalyticsSwitch = {},
+        )
     }
 }

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsScreen.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsScreen.kt
@@ -17,7 +17,7 @@ import org.mozilla.social.feature.settings.ui.SettingsGroup
 import org.mozilla.social.feature.settings.ui.SettingsSwitch
 
 @Composable
-fun PrivacySettingsScreen(viewModel: PrivacySettingsViewModel = koinViewModel()) {
+internal fun PrivacySettingsScreen(viewModel: PrivacySettingsViewModel = koinViewModel()) {
     val isAnalyticsToggled by viewModel.allowAnalytics.collectAsStateWithLifecycle()
 
     PrivacySettingsScreen(

--- a/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/mozilla/social/feature/settings/privacy/PrivacySettingsViewModel.kt
@@ -16,7 +16,7 @@ class PrivacySettingsViewModel(
     private val appPreferencesDatastore: AppPreferencesDatastore,
     private val analytics: Analytics,
     getLoggedInUserAccountId: GetLoggedInUserAccountId,
-) : ViewModel(), SettingsInteractions {
+) : ViewModel(), PrivacySettingsInteractions {
 
     private val userAccountId: String = getLoggedInUserAccountId()
 


### PR DESCRIPTION
- Removed all default interfaces values for settings interfaces
- Added new interfaces for each settings screen
- Cleaned up some compose code and fixed / added compose previews for some settings screens
- Moved `BlockedButtonState` and `MutedButtonState` into their own files