### PR TITLE
Remembering scroll position for different lists

### DIFF
--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/paging/SearchPagingColumn.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/paging/SearchPagingColumn.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,13 +29,21 @@ fun <A : Any> SearchPagingColumn(
     lazyPagingItems: LazyPagingItems<A>,
     modifier: Modifier = Modifier,
     noResultText: String,
+    listState: LazyListState = rememberLazyListState(),
+    emptyListState: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit,
 ) {
     Box(
         modifier = modifier
             .fillMaxSize(),
     ) {
-        LazyColumn {
+        LazyColumn(
+            state = if (lazyPagingItems.itemCount == 0) {
+                emptyListState
+            } else {
+                listState
+            },
+        ) {
             when (lazyPagingItems.loadState.refresh) {
                 is LoadState.Error -> {} // handle the error outside the lazy column
                 is LoadState.Loading -> {

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/pullrefresh/PullRefreshLazyColumn.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/pullrefresh/PullRefreshLazyColumn.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +43,8 @@ fun <A : Any> PullRefreshLazyColumn(
             )
 
         },
+    listState: LazyListState = rememberLazyListState(),
+    emptyListState: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit,
 ) {
     Box(
@@ -48,7 +52,14 @@ fun <A : Any> PullRefreshLazyColumn(
             .pullRefresh(pullRefreshState)
             .fillMaxSize(),
     ) {
-        LazyColumn(modifier = modifier) {
+        LazyColumn(
+            modifier = modifier,
+            state = if (lazyPagingItems.itemCount == 0) {
+                emptyListState
+            } else {
+                listState
+            },
+        ) {
             when (lazyPagingItems.loadState.refresh) {
                 is LoadState.Error -> {} // handle the error outside the lazy column
                 else -> {


### PR DESCRIPTION
- Applying the same solution we have for `PostCardList` to `SearchPagingColumn` and `PullRefreshLazyColumn`