### PR TITLE
Making PullRefreshLazyColumn use PagingLazyColumn

### DIFF
--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/paging/PagingLazyColumn.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/paging/PagingLazyColumn.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,17 +25,25 @@ import org.mozilla.social.core.ui.common.animation.DelayedVisibility
 import org.mozilla.social.core.ui.common.error.GenericError
 
 @Composable
-fun <A : Any> SearchPagingColumn(
+fun <A : Any> PagingLazyColumn(
     lazyPagingItems: LazyPagingItems<A>,
     modifier: Modifier = Modifier,
     noResultText: String,
+    listState: LazyListState = rememberLazyListState(),
+    emptyListState: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit,
 ) {
     Box(
         modifier = modifier
             .fillMaxSize(),
     ) {
-        LazyColumn {
+        LazyColumn(
+            state = if (lazyPagingItems.itemCount == 0) {
+                emptyListState
+            } else {
+                listState
+            },
+        ) {
             when (lazyPagingItems.loadState.refresh) {
                 is LoadState.Error -> {} // handle the error outside the lazy column
                 is LoadState.Loading -> {

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/pullrefresh/PullRefreshLazyColumn.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/pullrefresh/PullRefreshLazyColumn.kt
@@ -1,28 +1,19 @@
 package org.mozilla.social.core.ui.common.pullrefresh
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Text
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
-import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.ui.common.R
-import org.mozilla.social.core.ui.common.error.GenericError
+import org.mozilla.social.core.ui.common.paging.PagingLazyColumn
 
 @Composable
 fun <A : Any> PullRefreshLazyColumn(
@@ -41,72 +32,22 @@ fun <A : Any> PullRefreshLazyColumn(
             )
 
         },
+    listState: LazyListState = rememberLazyListState(),
+    emptyListState: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .pullRefresh(pullRefreshState)
             .fillMaxSize(),
     ) {
-        LazyColumn(modifier = modifier) {
-            when (lazyPagingItems.loadState.refresh) {
-                is LoadState.Error -> {} // handle the error outside the lazy column
-                else -> {
-                    content()
-                }
-            }
-
-            when (lazyPagingItems.loadState.append) {
-                is LoadState.Loading -> {
-                    item {
-                        CircularProgressIndicator(
-                            modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .wrapContentWidth(Alignment.CenterHorizontally)
-                                .padding(16.dp),
-                        )
-                    }
-                }
-
-                is LoadState.Error -> {
-                    item {
-                        GenericError(
-                            onRetryClicked = { lazyPagingItems.retry() },
-                        )
-                    }
-                }
-
-                is LoadState.NotLoading -> {
-                    item {
-                        if (lazyPagingItems.itemSnapshotList.isEmpty()) { // Show empty state
-                            Text(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .wrapContentWidth(Alignment.CenterHorizontally)
-                                    .padding(16.dp),
-                                text = stringResource(
-                                    id =
-                                    R.string.theres_nothing_here
-                                ),
-                            )
-                        } else { // It's the end of the list so add some space
-                            Spacer(modifier = Modifier.height(50.dp))
-                        }
-                    }
-                }
-            }
-        }
-
-        if (lazyPagingItems.loadState.refresh is LoadState.Error) {
-            GenericError(
-                modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(MoSoTheme.colors.layer1),
-                onRetryClicked = { lazyPagingItems.refresh() },
-            )
-        }
+        PagingLazyColumn(
+            lazyPagingItems = lazyPagingItems,
+            noResultText = stringResource(id = R.string.theres_nothing_here),
+            listState = listState,
+            emptyListState = emptyListState,
+            content = content,
+        )
 
         pullRefreshIndicator(
             lazyPagingItems.loadState.refresh == LoadState.Loading,

--- a/feature/search/src/main/java/org/mozilla/social/search/SearchScreen.kt
+++ b/feature/search/src/main/java/org/mozilla/social/search/SearchScreen.kt
@@ -67,7 +67,7 @@ import org.mozilla.social.core.ui.common.following.FollowingButton
 import org.mozilla.social.core.ui.common.hashtag.quickview.HashTagQuickView
 import org.mozilla.social.core.ui.common.hashtag.quickview.HashTagQuickViewUiState
 import org.mozilla.social.core.ui.common.loading.MaxSizeLoading
-import org.mozilla.social.core.ui.common.paging.SearchPagingColumn
+import org.mozilla.social.core.ui.common.paging.PagingLazyColumn
 import org.mozilla.social.core.ui.postcard.PostCard
 import org.mozilla.social.core.ui.postcard.PostCardInteractions
 import org.mozilla.social.core.ui.postcard.PostCardUiState
@@ -387,7 +387,7 @@ private fun AccountsList(
     searchInteractions: SearchInteractions,
 ) {
     accountFeed?.collectAsLazyPagingItems()?.let { lazyPagingItems ->
-        SearchPagingColumn(
+        PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
             noResultText = stringResource(id = R.string.search_empty)
         ) {
@@ -424,7 +424,7 @@ private fun StatusesList(
     postCardInteractions: PostCardInteractions,
 ) {
     statusFeed?.collectAsLazyPagingItems()?.let { lazyPagingItems ->
-        SearchPagingColumn(
+        PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
             noResultText = stringResource(id = R.string.search_empty)
         ) {
@@ -442,7 +442,7 @@ private fun HashTagsList(
     searchInteractions: SearchInteractions,
 ) {
     hashTagsFeed?.collectAsLazyPagingItems()?.let { lazyPagingItems ->
-        SearchPagingColumn(
+        PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
             noResultText = stringResource(id = R.string.search_empty)
         ) {


### PR DESCRIPTION
There are some empty state things that `PagingLazyColumn` does better that `PullRefreshLazyColumn`.  Instead of copying those things over, I'm just having `PullRefreshLazyColumn` use `PagingLazyColumn`.