### PR TITLE
Repost Notifications UI

### DIFF
--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/Mapping.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/Mapping.kt
@@ -30,6 +30,11 @@ fun Notification.toUiState(
         title = StringFactory.resource(resId = R.string.repost_title, account.displayName),
         avatarUrl = account.avatarUrl,
         accountId = account.accountId,
+        postContentUiState = status.toPostContentUiState(
+            currentUserAccountId = currentUserAccountId,
+            contentWarningOverride = "",
+        ),
+        statusId = status.statusId,
     )
     is Notification.Follow -> NotificationUiState.Follow(
         id = id,

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/Mapping.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/Mapping.kt
@@ -33,6 +33,7 @@ fun Notification.toUiState(
         postContentUiState = status.toPostContentUiState(
             currentUserAccountId = currentUserAccountId,
             contentWarningOverride = "",
+            onlyShowPreviewOfText = true,
         ),
         statusId = status.statusId,
     )

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationCard.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationCard.kt
@@ -33,7 +33,7 @@ import org.mozilla.social.core.ui.notifications.cards.FollowRequestNotification
 import org.mozilla.social.core.ui.notifications.cards.MentionNotificationContent
 import org.mozilla.social.core.ui.notifications.cards.NewStatusNotification
 import org.mozilla.social.core.ui.notifications.cards.PollEndedNotification
-import org.mozilla.social.core.ui.notifications.cards.RepostNotification
+import org.mozilla.social.core.ui.notifications.cards.RepostNotificationContent
 import org.mozilla.social.core.ui.notifications.cards.StatusUpdatedNotification
 import org.mozilla.social.core.ui.poll.PollInteractions
 
@@ -51,6 +51,9 @@ fun NotificationCard(
             is NotificationUiState.Follow -> FollowNotification(uiState = uiState)
             is NotificationUiState.FollowRequest -> FollowRequestNotification(uiState = uiState)
             is NotificationUiState.Mention -> NotificationCard(
+                modifier = Modifier.clickable {
+                    notificationInteractions.onMentionClicked(uiState.statusId)
+                },
                 uiState = uiState,
                 notificationInteractions = notificationInteractions,
                 notificationTypeIcon = MoSoIcons.at(),
@@ -64,7 +67,20 @@ fun NotificationCard(
 
             is NotificationUiState.NewStatus -> NewStatusNotification(uiState = uiState)
             is NotificationUiState.PollEnded -> PollEndedNotification(uiState = uiState)
-            is NotificationUiState.Repost -> RepostNotification(uiState = uiState)
+            is NotificationUiState.Repost -> NotificationCard(
+                modifier = Modifier.clickable {
+                    notificationInteractions.onRepostClicked(uiState.statusId)
+                },
+                uiState = uiState,
+                notificationInteractions = notificationInteractions,
+                notificationTypeIcon = MoSoIcons.boost(),
+            ) {
+                RepostNotificationContent(
+                    uiState = uiState,
+                    htmlContentInteractions = htmlContentInteractions,
+                    pollInteractions = pollInteractions
+                )
+            }
             is NotificationUiState.StatusUpdated -> StatusUpdatedNotification(uiState = uiState)
         }
     }

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationCardDelegate.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationCardDelegate.kt
@@ -14,4 +14,8 @@ class NotificationCardDelegate(
     override fun onMentionClicked(statusId: String) {
         navigateTo(NavigationDestination.Thread(statusId))
     }
+
+    override fun onRepostClicked(statusId: String) {
+        navigateTo(NavigationDestination.Thread(statusId))
+    }
 }

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationInteractions.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationInteractions.kt
@@ -3,4 +3,11 @@ package org.mozilla.social.core.ui.notifications
 interface NotificationInteractions {
     fun onAvatarClicked(accountId: String)
     fun onMentionClicked(statusId: String)
+    fun onRepostClicked(statusId: String)
+}
+
+object NotificationInteractionsNoOp : NotificationInteractions {
+    override fun onAvatarClicked(accountId: String) = Unit
+    override fun onMentionClicked(statusId: String) = Unit
+    override fun onRepostClicked(statusId: String) = Unit
 }

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationUiState.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/NotificationUiState.kt
@@ -34,6 +34,8 @@ sealed class NotificationUiState {
         override val avatarUrl: String,
         override val timeStamp: StringFactory,
         override val accountId: String,
+        val postContentUiState: PostContentUiState,
+        val statusId: String,
     ): NotificationUiState()
 
     data class Follow(

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/cards/Mention.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/cards/Mention.kt
@@ -7,6 +7,7 @@ import org.mozilla.social.core.ui.common.utils.PreviewTheme
 import org.mozilla.social.core.ui.htmlcontent.HtmlContentInteractions
 import org.mozilla.social.core.ui.notifications.NotificationCard
 import org.mozilla.social.core.ui.notifications.NotificationInteractions
+import org.mozilla.social.core.ui.notifications.NotificationInteractionsNoOp
 import org.mozilla.social.core.ui.notifications.NotificationUiState
 import org.mozilla.social.core.ui.poll.PollInteractions
 import org.mozilla.social.core.ui.postcard.PostContent
@@ -48,10 +49,7 @@ private fun MentionNotificationPreview() {
             ),
             htmlContentInteractions = object : HtmlContentInteractions {},
             pollInteractions = object : PollInteractions {},
-            notificationInteractions = object : NotificationInteractions {
-                override fun onAvatarClicked(accountId: String) = Unit
-                override fun onMentionClicked(statusId: String) = Unit
-            },
+            notificationInteractions = NotificationInteractionsNoOp,
         )
     }
 }

--- a/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/cards/Repost.kt
+++ b/core/ui/notifications/src/main/java/org/mozilla/social/core/ui/notifications/cards/Repost.kt
@@ -1,18 +1,54 @@
 package org.mozilla.social.core.ui.notifications.cards
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import org.mozilla.social.common.utils.StringFactory
+import org.mozilla.social.core.ui.common.utils.PreviewTheme
+import org.mozilla.social.core.ui.htmlcontent.HtmlContentInteractions
+import org.mozilla.social.core.ui.notifications.NotificationCard
+import org.mozilla.social.core.ui.notifications.NotificationInteractionsNoOp
 import org.mozilla.social.core.ui.notifications.NotificationUiState
+import org.mozilla.social.core.ui.poll.PollInteractions
+import org.mozilla.social.core.ui.postcard.PostContent
+import org.mozilla.social.core.ui.postcard.PostContentUiState
 
 @Composable
-fun RepostNotification(
-    uiState: NotificationUiState.Repost
+internal fun RepostNotificationContent(
+    uiState: NotificationUiState.Repost,
+    htmlContentInteractions: HtmlContentInteractions,
+    pollInteractions: PollInteractions,
 ) {
-    Text(
-        modifier = Modifier.padding(8.dp),
-        text = "Repost ${uiState.id}"
+    PostContent(
+        uiState = uiState.postContentUiState,
+        htmlContentInteractions = htmlContentInteractions,
+        pollInteractions = pollInteractions,
     )
+}
+
+@Preview
+@Composable
+private fun RepostNotificationPreview() {
+    PreviewTheme {
+        NotificationCard(
+            uiState = NotificationUiState.Repost(
+                id = 1,
+                timeStamp = StringFactory.literal("1 day ago"),
+                title = StringFactory.literal("John mentioned you:"),
+                avatarUrl = "",
+                postContentUiState = PostContentUiState(
+                    pollUiState = null,
+                    statusTextHtml = "this is a status",
+                    mediaAttachments = emptyList(),
+                    mentions = emptyList(),
+                    previewCard = null,
+                    contentWarning = "",
+                ),
+                accountId = "",
+                statusId = "",
+            ),
+            htmlContentInteractions = object : HtmlContentInteractions {},
+            pollInteractions = object : PollInteractions {},
+            notificationInteractions = NotificationInteractionsNoOp,
+        )
+    }
 }

--- a/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
+++ b/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCard.kt
@@ -234,6 +234,16 @@ fun PostContent(
                 mentions = uiState.mentions,
                 htmlText = uiState.statusTextHtml,
                 htmlContentInteractions = htmlContentInteractions,
+                maximumLineCount = if (uiState.onlyShowPreviewOfText) {
+                    1
+                } else {
+                    Int.MAX_VALUE
+                },
+                textColor = if (uiState.onlyShowPreviewOfText) {
+                    MoSoTheme.colors.textSecondary
+                } else {
+                    MoSoTheme.colors.textPrimary
+                }
             )
             Spacer(modifier = Modifier.padding(top = 8.dp))
 

--- a/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardMapping.kt
+++ b/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardMapping.kt
@@ -38,7 +38,10 @@ private fun Status.toMainPostCardUiState(currentUserAccountId: String): MainPost
         postContentUiState = toPostContentUiState(currentUserAccountId)
     )
 
-fun Status.toPostContentUiState(currentUserAccountId: String): PostContentUiState = PostContentUiState(
+fun Status.toPostContentUiState(
+    currentUserAccountId: String,
+    contentWarningOverride: String? = null,
+): PostContentUiState = PostContentUiState(
     pollUiState = poll?.toPollUiState(
         isUserCreatedPoll = currentUserAccountId == account.accountId,
     ),
@@ -46,7 +49,7 @@ fun Status.toPostContentUiState(currentUserAccountId: String): PostContentUiStat
     mediaAttachments = mediaAttachments,
     mentions = mentions,
     previewCard = card?.toPreviewCard(),
-    contentWarning = contentWarningText,
+    contentWarning = contentWarningOverride ?: contentWarningText,
 )
 
 private fun Status.toTopRowMetaDataUiState(): TopRowMetaDataUiState? =

--- a/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardMapping.kt
+++ b/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardMapping.kt
@@ -41,6 +41,7 @@ private fun Status.toMainPostCardUiState(currentUserAccountId: String): MainPost
 fun Status.toPostContentUiState(
     currentUserAccountId: String,
     contentWarningOverride: String? = null,
+    onlyShowPreviewOfText: Boolean = false,
 ): PostContentUiState = PostContentUiState(
     pollUiState = poll?.toPollUiState(
         isUserCreatedPoll = currentUserAccountId == account.accountId,
@@ -50,6 +51,7 @@ fun Status.toPostContentUiState(
     mentions = mentions,
     previewCard = card?.toPreviewCard(),
     contentWarning = contentWarningOverride ?: contentWarningText,
+    onlyShowPreviewOfText = onlyShowPreviewOfText,
 )
 
 private fun Status.toTopRowMetaDataUiState(): TopRowMetaDataUiState? =

--- a/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardUiState.kt
+++ b/core/ui/postcard/src/main/java/org/mozilla/social/core/ui/postcard/PostCardUiState.kt
@@ -39,6 +39,7 @@ data class PostContentUiState(
     val mentions: List<Mention>,
     val previewCard: PreviewCard?,
     val contentWarning: String,
+    val onlyShowPreviewOfText: Boolean = false,
 )
 
 data class TopRowMetaDataUiState(

--- a/feature/notifications/src/main/java/org/mozilla/social/feature/notifications/NotificationsScreen.kt
+++ b/feature/notifications/src/main/java/org/mozilla/social/feature/notifications/NotificationsScreen.kt
@@ -33,6 +33,7 @@ import org.mozilla.social.core.ui.common.utils.PreviewTheme
 import org.mozilla.social.core.ui.htmlcontent.HtmlContentInteractions
 import org.mozilla.social.core.ui.notifications.NotificationCard
 import org.mozilla.social.core.ui.notifications.NotificationInteractions
+import org.mozilla.social.core.ui.notifications.NotificationInteractionsNoOp
 import org.mozilla.social.core.ui.notifications.NotificationUiState
 import org.mozilla.social.core.ui.poll.PollInteractions
 
@@ -167,10 +168,7 @@ private fun NotificationsScreenPreview() {
             },
             pollInteractions = object : PollInteractions {},
             htmlContentInteractions = object : HtmlContentInteractions {},
-            notificationInteractions = object : NotificationInteractions {
-                override fun onAvatarClicked(accountId: String) = Unit
-                override fun onMentionClicked(statusId: String) = Unit
-            },
+            notificationInteractions = NotificationInteractionsNoOp,
         )
     }
 }


### PR DESCRIPTION
- Adding a UI for repost notifications
- Adding a no-op implementation of `NotificationInteractions` for use with compose previews
  - I want to start doing this instead of having default `Unit` values for interface functions
- Adding a post preview state for `PostContentUiState`