### PR TITLE
Removing unused buttons in discover

### DIFF
--- a/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverScreen.kt
@@ -192,18 +192,6 @@ private fun Recommendation(
             }
             Row {
                 Spacer(modifier = Modifier.weight(1f))
-                IconButton(onClick = { discoverInteractions.onRepostClicked(recommendation.id) }) {
-                    Icon(
-                        painter = MoSoIcons.boost(),
-                        contentDescription = stringResource(id = R.string.repost_content_description),
-                    )
-                }
-                IconButton(onClick = { discoverInteractions.onBookmarkClicked(recommendation.id) }) {
-                    Icon(
-                        painter = MoSoIcons.bookmarkBorder(),
-                        contentDescription = stringResource(id = R.string.bookmark_content_description),
-                    )
-                }
                 IconButton(onClick = {
                     shareUrl(recommendation.url, context)
                     discoverInteractions.onShareClicked(recommendation.id)


### PR DESCRIPTION
We don't have plans to continue work on discover for alpha or beta.  I'm remove the bookmark and repost buttons because they don't do anything right now.