### PR TITLE
New post cleanup

### DIFF
--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostInteractions.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostInteractions.kt
@@ -1,9 +1,19 @@
 package org.mozilla.social.post
 
+import org.mozilla.social.core.model.StatusVisibility
+
 interface NewPostInteractions {
-    fun onScreenViewed() = Unit
+    fun onScreenViewed()
+    fun onUploadImageClicked()
+    fun onUploadMediaClicked()
+    fun onPostClicked()
+    fun onVisibilitySelected(statusVisibility: StatusVisibility)
+}
 
-    fun onUploadImageClicked() = Unit
-
-    fun onUploadMediaClicked() = Unit
+object NewPostInteractionsNoOp : NewPostInteractions {
+    override fun onScreenViewed() = Unit
+    override fun onUploadImageClicked() = Unit
+    override fun onUploadMediaClicked() = Unit
+    override fun onPostClicked() = Unit
+    override fun onVisibilitySelected(statusVisibility: StatusVisibility) = Unit
 }

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
@@ -8,30 +8,38 @@ import org.mozilla.social.core.datastore.dataStoreModule
 import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
 import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
+import org.mozilla.social.post.status.StatusDelegate
 
-val newPostModule =
-    module {
-        includes(
-            commonModule,
-            mastodonRepositoryModule,
-            dataStoreModule,
-            mastodonUsecaseModule,
-            navigationModule,
-            analyticsModule,
+val newPostModule = module {
+    includes(
+        commonModule,
+        mastodonRepositoryModule,
+        dataStoreModule,
+        mastodonUsecaseModule,
+        navigationModule,
+        analyticsModule,
+    )
+
+    viewModel { parametersHolder ->
+        NewPostViewModel(
+            analytics = get(),
+            replyStatusId = parametersHolder.getOrNull(),
+            mediaRepository = get(),
+            postStatus = get(),
+            popNavBackstack = get(),
+            showSnackbar = get(),
+            getLoggedInUserAccountId = get(),
+            accountRepository = get(),
         )
-
-        viewModel { parametersHolder ->
-            NewPostViewModel(
-                analytics = get(),
-                replyStatusId = parametersHolder.getOrNull(),
-                mediaRepository = get(),
-                searchRepository = get(),
-                statusRepository = get(),
-                postStatus = get(),
-                popNavBackstack = get(),
-                showSnackbar = get(),
-                getLoggedInUserAccountId = get(),
-                accountRepository = get(),
-            )
-        }
     }
+
+    factory { parametersHolder ->
+        StatusDelegate(
+            analytics = get(),
+            searchRepository = get(),
+            statusRepository = get(),
+            coroutineScope = parametersHolder[0],
+            inReplyToId = parametersHolder[1],
+        )
+    }
+}

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
@@ -1,6 +1,7 @@
 package org.mozilla.social.post
 
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 import org.mozilla.social.common.commonModule
 import org.mozilla.social.core.analytics.analyticsModule
@@ -8,6 +9,7 @@ import org.mozilla.social.core.datastore.dataStoreModule
 import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
 import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
+import org.mozilla.social.post.poll.PollDelegate
 import org.mozilla.social.post.status.StatusDelegate
 
 val newPostModule = module {
@@ -42,4 +44,6 @@ val newPostModule = module {
             inReplyToId = parametersHolder[1],
         )
     }
+
+    factoryOf(::PollDelegate)
 }

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
@@ -9,6 +9,7 @@ import org.mozilla.social.core.datastore.dataStoreModule
 import org.mozilla.social.core.navigation.navigationModule
 import org.mozilla.social.core.repository.mastodon.mastodonRepositoryModule
 import org.mozilla.social.core.usecase.mastodon.mastodonUsecaseModule
+import org.mozilla.social.post.media.MediaDelegate
 import org.mozilla.social.post.poll.PollDelegate
 import org.mozilla.social.post.status.StatusDelegate
 
@@ -26,7 +27,6 @@ val newPostModule = module {
         NewPostViewModel(
             analytics = get(),
             replyStatusId = parametersHolder.getOrNull(),
-            mediaRepository = get(),
             postStatus = get(),
             popNavBackstack = get(),
             showSnackbar = get(),
@@ -46,4 +46,11 @@ val newPostModule = module {
     }
 
     factoryOf(::PollDelegate)
+
+    factory { parametersHolder ->
+        MediaDelegate(
+            coroutineScope = parametersHolder[0],
+            mediaRepository = get(),
+        )
+    }
 }

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostModule.kt
@@ -32,6 +32,7 @@ val newPostModule = module {
             showSnackbar = get(),
             getLoggedInUserAccountId = get(),
             accountRepository = get(),
+            pollDelegate = get(),
         )
     }
 

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
@@ -59,7 +59,6 @@ import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.mozilla.social.common.LoadState
 import org.mozilla.social.common.utils.buildAnnotatedStringForAccountsAndHashtags
-import org.mozilla.social.core.analytics.Analytics
 import org.mozilla.social.core.designsystem.icon.MoSoIcons
 import org.mozilla.social.core.designsystem.theme.MoSoSpacing
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
@@ -88,31 +87,28 @@ import org.mozilla.social.post.poll.PollDurationDropDown
 import org.mozilla.social.post.poll.PollInteractions
 import org.mozilla.social.post.poll.PollStyle
 import org.mozilla.social.post.poll.PollStyleDropDown
-import org.mozilla.social.post.status.Account
 import org.mozilla.social.post.status.AccountSearchBar
 import org.mozilla.social.post.status.ContentWarningInteractions
 import org.mozilla.social.post.status.HashtagSearchBar
 import org.mozilla.social.post.status.StatusInteractions
+import org.mozilla.social.post.status.StatusUiState
 
 @Composable
 internal fun NewPostScreen(
     replyStatusId: String?,
     viewModel: NewPostViewModel = koinViewModel(parameters = { parametersOf(replyStatusId) }),
 ) {
-    val statusText by viewModel.statusText.collectAsStateWithLifecycle()
+    val statusUiState by viewModel.statusUiState.collectAsStateWithLifecycle()
     val sendButtonEnabled by viewModel.sendButtonEnabled.collectAsStateWithLifecycle()
     val mediaStates by viewModel.mediaStates.collectAsStateWithLifecycle()
     val isSendingPost by viewModel.isSendingPost.collectAsStateWithLifecycle()
     val visibility by viewModel.visibility.collectAsStateWithLifecycle()
     val poll by viewModel.poll.collectAsStateWithLifecycle()
-    val contextWarningText by viewModel.contentWarningText.collectAsStateWithLifecycle()
-    val accounts by viewModel.accountList.collectAsStateWithLifecycle()
-    val hashTags by viewModel.hashtagList.collectAsStateWithLifecycle()
-    val inReplyToAccountName by viewModel.inReplyToAccountName.collectAsStateWithLifecycle()
     val userHeaderState by viewModel.userHeaderState.collectAsStateWithLifecycle(initialValue = null)
     val bottomBarState by viewModel.bottomBarState.collectAsStateWithLifecycle()
+
     NewPostScreen(
-        statusText = statusText,
+        statusUiState = statusUiState,
         statusInteractions = viewModel.statusInteractions,
         onPostClicked = viewModel::onPostClicked,
         sendButtonEnabled = sendButtonEnabled,
@@ -123,11 +119,7 @@ internal fun NewPostScreen(
         onVisibilitySelected = viewModel::onVisibilitySelected,
         poll = poll,
         pollInteractions = viewModel.pollInteractions,
-        contentWarningText = contextWarningText,
         contentWarningInteractions = viewModel.contentWarningInteractions,
-        accounts = accounts,
-        hashTags = hashTags,
-        inReplyToAccountName = inReplyToAccountName,
         userHeaderState = userHeaderState,
         bottomBarState = bottomBarState,
         onUploadImageClicked = viewModel::onUploadImageClicked,
@@ -143,8 +135,8 @@ data class UserHeaderState(val avatarUrl: String, val displayName: String)
 
 @Composable
 private fun NewPostScreen(
+    statusUiState: StatusUiState,
     bottomBarState: BottomBarState,
-    statusText: TextFieldValue,
     statusInteractions: StatusInteractions,
     onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
@@ -155,26 +147,22 @@ private fun NewPostScreen(
     onVisibilitySelected: (StatusVisibility) -> Unit,
     poll: Poll?,
     pollInteractions: PollInteractions,
-    contentWarningText: String?,
     contentWarningInteractions: ContentWarningInteractions,
-    accounts: List<Account>?,
-    hashTags: List<String>?,
-    inReplyToAccountName: String?,
     userHeaderState: UserHeaderState?,
     onUploadImageClicked: () -> Unit,
     onUploadMediaClicked: () -> Unit
 ) {
     Box(
         modifier =
-            Modifier
-                .systemBarsPadding()
-                .imePadding()
-                .background(MoSoTheme.colors.layer1),
+        Modifier
+            .systemBarsPadding()
+            .imePadding()
+            .background(MoSoTheme.colors.layer1),
     ) {
         if (getWindowHeightClass() == WindowHeightSizeClass.Compact) {
             Row {
                 CompactNewPostScreenContent(
-                    statusText = statusText,
+                    statusUiState = statusUiState,
                     statusInteractions = statusInteractions,
                     onPostClicked = onPostClicked,
                     sendButtonEnabled = sendButtonEnabled,
@@ -182,15 +170,13 @@ private fun NewPostScreen(
                     mediaInteractions = mediaInteractions,
                     poll = poll,
                     pollInteractions = pollInteractions,
-                    contentWarningText = contentWarningText,
                     contentWarningInteractions = contentWarningInteractions,
-                    inReplyToAccountName = inReplyToAccountName,
                 )
             }
         } else {
             NewPostScreenContent(
+                statusUiState = statusUiState,
                 bottomBarState = bottomBarState,
-                statusText = statusText,
                 statusInteractions = statusInteractions,
                 onPostClicked = onPostClicked,
                 sendButtonEnabled = sendButtonEnabled,
@@ -200,11 +186,7 @@ private fun NewPostScreen(
                 onVisibilitySelected = onVisibilitySelected,
                 poll = poll,
                 pollInteractions = pollInteractions,
-                contentWarningText = contentWarningText,
                 contentWarningInteractions = contentWarningInteractions,
-                accounts = accounts,
-                hashTags = hashTags,
-                inReplyToAccountName = inReplyToAccountName,
                 userHeaderState = userHeaderState,
                 onUploadImageClicked = onUploadImageClicked,
                 onUploadMediaClicked = onUploadMediaClicked
@@ -222,7 +204,7 @@ private fun NewPostScreen(
 
 @Composable
 private fun CompactNewPostScreenContent(
-    statusText: TextFieldValue,
+    statusUiState: StatusUiState,
     statusInteractions: StatusInteractions,
     onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
@@ -230,9 +212,7 @@ private fun CompactNewPostScreenContent(
     mediaInteractions: MediaInteractions,
     poll: Poll?,
     pollInteractions: PollInteractions,
-    contentWarningText: String?,
     contentWarningInteractions: ContentWarningInteractions,
-    inReplyToAccountName: String?,
 ) {
     Row {
         Box(
@@ -241,15 +221,13 @@ private fun CompactNewPostScreenContent(
                     .weight(1f),
         ) {
             MainBox(
-                statusText = statusText,
+                statusUiState = statusUiState,
                 statusInteractions = statusInteractions,
                 imageStates = imageStates,
                 mediaInteractions = mediaInteractions,
                 poll = poll,
                 pollInteractions = pollInteractions,
-                contentWarningText = contentWarningText,
                 contentWarningInteractions = contentWarningInteractions,
-                inReplyToAccountName = inReplyToAccountName,
             )
         }
 
@@ -263,8 +241,8 @@ private fun CompactNewPostScreenContent(
 
 @Composable
 private fun NewPostScreenContent(
+    statusUiState: StatusUiState,
     bottomBarState: BottomBarState,
-    statusText: TextFieldValue,
     statusInteractions: StatusInteractions,
     onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
@@ -274,11 +252,7 @@ private fun NewPostScreenContent(
     onVisibilitySelected: (StatusVisibility) -> Unit,
     poll: Poll?,
     pollInteractions: PollInteractions,
-    contentWarningText: String?,
     contentWarningInteractions: ContentWarningInteractions,
-    accounts: List<Account>?,
-    hashTags: List<String>?,
-    inReplyToAccountName: String?,
     userHeaderState: UserHeaderState?,
     onUploadImageClicked: () -> Unit,
     onUploadMediaClicked: () -> Unit,
@@ -301,22 +275,20 @@ private fun NewPostScreenContent(
                     .weight(1f),
         ) {
             MainBox(
-                statusText = statusText,
+                statusUiState = statusUiState,
                 statusInteractions = statusInteractions,
                 imageStates = imageStates,
                 mediaInteractions = mediaInteractions,
                 poll = poll,
                 pollInteractions = pollInteractions,
-                contentWarningText = contentWarningText,
                 contentWarningInteractions = contentWarningInteractions,
-                inReplyToAccountName = inReplyToAccountName,
             )
         }
-        accounts?.let {
-            AccountSearchBar(accounts = accounts, statusInteractions = statusInteractions)
+        statusUiState.accountList?.let {
+            AccountSearchBar(accounts = statusUiState.accountList, statusInteractions = statusInteractions)
         }
-        hashTags?.let {
-            HashtagSearchBar(hashTags = hashTags, statusInteractions = statusInteractions)
+        statusUiState.hashtagList?.let {
+            HashtagSearchBar(hashTags = statusUiState.hashtagList, statusInteractions = statusInteractions)
         }
         BottomBar(
             bottomBarState = bottomBarState,
@@ -395,15 +367,13 @@ private fun PostButton(
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun MainBox(
-    statusText: TextFieldValue,
+    statusUiState: StatusUiState,
     statusInteractions: StatusInteractions,
     imageStates: List<ImageState>,
     mediaInteractions: MediaInteractions,
     poll: Poll?,
     pollInteractions: PollInteractions,
-    contentWarningText: String?,
     contentWarningInteractions: ContentWarningInteractions,
-    inReplyToAccountName: String?,
 ) {
     val localIndication = LocalIndication.current
     // disable ripple on click for the background
@@ -427,11 +397,11 @@ private fun MainBox(
             ) {
                 LazyColumn {
                     item {
-                        InReplyToText(inReplyToAccountName = inReplyToAccountName)
+                        InReplyToText(inReplyToAccountName = statusUiState.inReplyToAccountName)
                     }
-                    contentWarningText?.let {
+                    statusUiState.contentWarningText?.let {
                         item {
-                            ContentWarningEntry(contentWarningText, contentWarningInteractions)
+                            ContentWarningEntry(statusUiState.contentWarningText, contentWarningInteractions)
                         }
                     }
 
@@ -442,7 +412,7 @@ private fun MainBox(
                                 Modifier
                                     .fillMaxWidth()
                                     .focusRequester(textFieldFocusRequester),
-                            value = statusText,
+                            value = statusUiState.statusText,
                             onValueChange = { statusInteractions.onStatusTextUpdated(it) },
                             label = {
                                 Text(
@@ -715,7 +685,13 @@ private fun NewPostScreenPreview() {
         false,
     ) {
         NewPostScreen(
-            statusText = TextFieldValue(),
+            statusUiState = StatusUiState(
+                statusText = TextFieldValue(),
+                contentWarningText = null,
+                accountList = null,
+                hashtagList = null,
+                inReplyToAccountName = null,
+            ),
             statusInteractions = object : StatusInteractions {},
             onPostClicked = {},
             sendButtonEnabled = true,
@@ -726,11 +702,7 @@ private fun NewPostScreenPreview() {
             onVisibilitySelected = {},
             poll = null,
             pollInteractions = object : PollInteractions {},
-            contentWarningText = null,
             contentWarningInteractions = object : ContentWarningInteractions {},
-            accounts = null,
-            hashTags = null,
-            inReplyToAccountName = null,
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
             onUploadImageClicked = {},
@@ -746,7 +718,13 @@ private fun NewPostScreenWithPollPreview() {
         false,
     ) {
         NewPostScreen(
-            statusText = TextFieldValue(),
+            statusUiState = StatusUiState(
+                statusText = TextFieldValue(),
+                contentWarningText = null,
+                accountList = null,
+                hashtagList = null,
+                inReplyToAccountName = null,
+            ),
             statusInteractions = object : StatusInteractions {},
             onPostClicked = {},
             sendButtonEnabled = true,
@@ -763,11 +741,7 @@ private fun NewPostScreenWithPollPreview() {
                     hideTotals = false,
                 ),
             pollInteractions = object : PollInteractions {},
-            contentWarningText = null,
             contentWarningInteractions = object : ContentWarningInteractions {},
-            accounts = null,
-            hashTags = null,
-            inReplyToAccountName = null,
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
             onUploadImageClicked = {},
@@ -783,7 +757,13 @@ private fun NewPostScreenWithContentWarningPreview() {
         false,
     ) {
         NewPostScreen(
-            statusText = TextFieldValue(),
+            statusUiState = StatusUiState(
+                statusText = TextFieldValue(),
+                contentWarningText = "Content is bad",
+                accountList = null,
+                hashtagList = null,
+                inReplyToAccountName = null,
+            ),
             statusInteractions = object : StatusInteractions {},
             onPostClicked = {},
             sendButtonEnabled = true,
@@ -794,11 +774,7 @@ private fun NewPostScreenWithContentWarningPreview() {
             onVisibilitySelected = {},
             poll = null,
             pollInteractions = object : PollInteractions {},
-            contentWarningText = "Content is bad",
             contentWarningInteractions = object : ContentWarningInteractions {},
-            accounts = null,
-            hashTags = null,
-            inReplyToAccountName = null,
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
             onUploadImageClicked = {},

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
@@ -110,20 +110,17 @@ internal fun NewPostScreen(
     NewPostScreen(
         statusUiState = statusUiState,
         statusInteractions = viewModel.statusDelegate,
-        onPostClicked = viewModel::onPostClicked,
         sendButtonEnabled = sendButtonEnabled,
         imageStates = mediaStates,
         mediaInteractions = viewModel.mediaDelegate,
         isSendingPost = isSendingPost,
         visibility = visibility,
-        onVisibilitySelected = viewModel::onVisibilitySelected,
         pollUiState = pollUiState,
         pollInteractions = viewModel.pollDelegate,
         contentWarningInteractions = viewModel.statusDelegate,
         userHeaderState = userHeaderState,
         bottomBarState = bottomBarState,
-        onUploadImageClicked = viewModel::onUploadImageClicked,
-        onUploadMediaClicked = viewModel::onUploadMediaClicked
+        newPostInteractions = viewModel,
     )
 
     LaunchedEffect(Unit) {
@@ -138,19 +135,16 @@ private fun NewPostScreen(
     statusUiState: StatusUiState,
     bottomBarState: BottomBarState,
     statusInteractions: StatusInteractions,
-    onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
     imageStates: List<ImageState>,
     mediaInteractions: MediaInteractions,
     isSendingPost: Boolean,
     visibility: StatusVisibility,
-    onVisibilitySelected: (StatusVisibility) -> Unit,
     pollUiState: PollUiState?,
     pollInteractions: PollInteractions,
     contentWarningInteractions: ContentWarningInteractions,
     userHeaderState: UserHeaderState?,
-    onUploadImageClicked: () -> Unit,
-    onUploadMediaClicked: () -> Unit
+    newPostInteractions: NewPostInteractions,
 ) {
     Box(
         modifier =
@@ -164,13 +158,13 @@ private fun NewPostScreen(
                 CompactNewPostScreenContent(
                     statusUiState = statusUiState,
                     statusInteractions = statusInteractions,
-                    onPostClicked = onPostClicked,
                     sendButtonEnabled = sendButtonEnabled,
                     imageStates = imageStates,
                     mediaInteractions = mediaInteractions,
                     pollUiState = pollUiState,
                     pollInteractions = pollInteractions,
                     contentWarningInteractions = contentWarningInteractions,
+                    newPostInteractions = newPostInteractions,
                 )
             }
         } else {
@@ -178,18 +172,15 @@ private fun NewPostScreen(
                 statusUiState = statusUiState,
                 bottomBarState = bottomBarState,
                 statusInteractions = statusInteractions,
-                onPostClicked = onPostClicked,
                 sendButtonEnabled = sendButtonEnabled,
                 imageStates = imageStates,
                 mediaInteractions = mediaInteractions,
                 visibility = visibility,
-                onVisibilitySelected = onVisibilitySelected,
                 pollUiState = pollUiState,
                 pollInteractions = pollInteractions,
                 contentWarningInteractions = contentWarningInteractions,
                 userHeaderState = userHeaderState,
-                onUploadImageClicked = onUploadImageClicked,
-                onUploadMediaClicked = onUploadMediaClicked
+                newPostInteractions = newPostInteractions,
             )
         }
 
@@ -206,13 +197,13 @@ private fun NewPostScreen(
 private fun CompactNewPostScreenContent(
     statusUiState: StatusUiState,
     statusInteractions: StatusInteractions,
-    onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
     imageStates: List<ImageState>,
     mediaInteractions: MediaInteractions,
     pollUiState: PollUiState?,
     pollInteractions: PollInteractions,
     contentWarningInteractions: ContentWarningInteractions,
+    newPostInteractions: NewPostInteractions,
 ) {
     Row {
         Box(
@@ -233,7 +224,7 @@ private fun CompactNewPostScreenContent(
 
         PostButton(
             modifier = Modifier.padding(end = 16.dp),
-            onPostClicked = onPostClicked,
+            onPostClicked = newPostInteractions::onPostClicked,
             sendButtonEnabled = sendButtonEnabled,
         )
     }
@@ -244,29 +235,26 @@ private fun NewPostScreenContent(
     statusUiState: StatusUiState,
     bottomBarState: BottomBarState,
     statusInteractions: StatusInteractions,
-    onPostClicked: () -> Unit,
     sendButtonEnabled: Boolean,
     imageStates: List<ImageState>,
     mediaInteractions: MediaInteractions,
     visibility: StatusVisibility,
-    onVisibilitySelected: (StatusVisibility) -> Unit,
     pollUiState: PollUiState?,
     pollInteractions: PollInteractions,
     contentWarningInteractions: ContentWarningInteractions,
     userHeaderState: UserHeaderState?,
-    onUploadImageClicked: () -> Unit,
-    onUploadMediaClicked: () -> Unit,
+    newPostInteractions: NewPostInteractions,
 ) {
     Column {
         TopBar(
-            onPostClicked = onPostClicked,
+            onPostClicked = newPostInteractions::onPostClicked,
             sendButtonEnabled = sendButtonEnabled,
         )
         userHeaderState?.let { userHeaderState ->
             UserHeader(
                 userHeaderState = userHeaderState,
                 visibility = visibility,
-                onVisibilitySelected = onVisibilitySelected,
+                onVisibilitySelected = newPostInteractions::onVisibilitySelected,
             )
         }
         Box(
@@ -295,8 +283,8 @@ private fun NewPostScreenContent(
             onMediaInserted = mediaInteractions::onMediaInserted,
             pollInteractions = pollInteractions,
             contentWarningInteractions = contentWarningInteractions,
-            onUploadImageClicked = onUploadImageClicked,
-            onUploadMediaClicked = onUploadMediaClicked
+            onUploadImageClicked = newPostInteractions::onUploadImageClicked,
+            onUploadMediaClicked = newPostInteractions::onUploadMediaClicked,
         )
     }
 }
@@ -693,20 +681,17 @@ private fun NewPostScreenPreview() {
                 inReplyToAccountName = null,
             ),
             statusInteractions = object : StatusInteractions {},
-            onPostClicked = {},
             sendButtonEnabled = true,
             imageStates = listOf(),
             mediaInteractions = object : MediaInteractions {},
             isSendingPost = false,
             visibility = StatusVisibility.Private,
-            onVisibilitySelected = {},
             pollUiState = null,
             pollInteractions = object : PollInteractions {},
             contentWarningInteractions = object : ContentWarningInteractions {},
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
-            onUploadImageClicked = {},
-            onUploadMediaClicked = {},
+            newPostInteractions = NewPostInteractionsNoOp,
         )
     }
 }
@@ -726,13 +711,11 @@ private fun NewPostScreenWithPollPreview() {
                 inReplyToAccountName = null,
             ),
             statusInteractions = object : StatusInteractions {},
-            onPostClicked = {},
             sendButtonEnabled = true,
             imageStates = listOf(),
             mediaInteractions = object : MediaInteractions {},
             isSendingPost = false,
             visibility = StatusVisibility.Private,
-            onVisibilitySelected = {},
             pollUiState =
                 PollUiState(
                     options = listOf("option 1", "option 2"),
@@ -744,8 +727,7 @@ private fun NewPostScreenWithPollPreview() {
             contentWarningInteractions = object : ContentWarningInteractions {},
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
-            onUploadImageClicked = {},
-            onUploadMediaClicked = {},
+            newPostInteractions = NewPostInteractionsNoOp,
         )
     }
 }
@@ -765,20 +747,17 @@ private fun NewPostScreenWithContentWarningPreview() {
                 inReplyToAccountName = null,
             ),
             statusInteractions = object : StatusInteractions {},
-            onPostClicked = {},
             sendButtonEnabled = true,
             imageStates = listOf(),
             mediaInteractions = object : MediaInteractions {},
             isSendingPost = false,
             visibility = StatusVisibility.Private,
-            onVisibilitySelected = {},
             pollUiState = null,
             pollInteractions = object : PollInteractions {},
             contentWarningInteractions = object : ContentWarningInteractions {},
             userHeaderState = UserHeaderState("", "Barack Obama"),
             bottomBarState = BottomBarState(),
-            onUploadImageClicked = {},
-            onUploadMediaClicked = {},
+            newPostInteractions = NewPostInteractionsNoOp,
         )
     }
 }

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
@@ -100,7 +100,7 @@ internal fun NewPostScreen(
 ) {
     val statusUiState by viewModel.statusDelegate.uiState.collectAsStateWithLifecycle()
     val sendButtonEnabled by viewModel.sendButtonEnabled.collectAsStateWithLifecycle()
-    val mediaStates by viewModel.mediaStates.collectAsStateWithLifecycle()
+    val mediaStates by viewModel.mediaDelegate.imageStates.collectAsStateWithLifecycle()
     val isSendingPost by viewModel.isSendingPost.collectAsStateWithLifecycle()
     val visibility by viewModel.visibility.collectAsStateWithLifecycle()
     val pollUiState by viewModel.pollDelegate.uiState.collectAsStateWithLifecycle()
@@ -113,7 +113,7 @@ internal fun NewPostScreen(
         onPostClicked = viewModel::onPostClicked,
         sendButtonEnabled = sendButtonEnabled,
         imageStates = mediaStates,
-        mediaInteractions = viewModel.mediaInteractions,
+        mediaInteractions = viewModel.mediaDelegate,
         isSendingPost = isSendingPost,
         visibility = visibility,
         onVisibilitySelected = viewModel::onVisibilitySelected,

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostScreen.kt
@@ -98,7 +98,7 @@ internal fun NewPostScreen(
     replyStatusId: String?,
     viewModel: NewPostViewModel = koinViewModel(parameters = { parametersOf(replyStatusId) }),
 ) {
-    val statusUiState by viewModel.statusUiState.collectAsStateWithLifecycle()
+    val statusUiState by viewModel.statusDelegate.uiState.collectAsStateWithLifecycle()
     val sendButtonEnabled by viewModel.sendButtonEnabled.collectAsStateWithLifecycle()
     val mediaStates by viewModel.mediaStates.collectAsStateWithLifecycle()
     val isSendingPost by viewModel.isSendingPost.collectAsStateWithLifecycle()
@@ -109,7 +109,7 @@ internal fun NewPostScreen(
 
     NewPostScreen(
         statusUiState = statusUiState,
-        statusInteractions = viewModel.statusInteractions,
+        statusInteractions = viewModel.statusDelegate,
         onPostClicked = viewModel::onPostClicked,
         sendButtonEnabled = sendButtonEnabled,
         imageStates = mediaStates,
@@ -119,7 +119,7 @@ internal fun NewPostScreen(
         onVisibilitySelected = viewModel::onVisibilitySelected,
         poll = poll,
         pollInteractions = viewModel.pollInteractions,
-        contentWarningInteractions = viewModel.contentWarningInteractions,
+        contentWarningInteractions = viewModel.statusDelegate,
         userHeaderState = userHeaderState,
         bottomBarState = bottomBarState,
         onUploadImageClicked = viewModel::onUploadImageClicked,

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostUiState.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostUiState.kt
@@ -1,0 +1,14 @@
+package org.mozilla.social.post
+
+import org.mozilla.social.core.model.StatusVisibility
+import org.mozilla.social.post.bottombar.BottomBarState
+
+data class NewPostUiState(
+    val visibility: StatusVisibility = StatusVisibility.Public,
+    val isSendingPost: Boolean = false,
+    val sendButtonEnabled: Boolean = false,
+    val bottomBarState: BottomBarState = BottomBarState(),
+    val userHeaderState: UserHeaderState? = null,
+)
+
+data class UserHeaderState(val avatarUrl: String, val displayName: String)

--- a/feature/post/src/main/java/org/mozilla/social/post/NewPostViewModel.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/NewPostViewModel.kt
@@ -125,11 +125,11 @@ class NewPostViewModel(
             }
         }
 
-    fun onVisibilitySelected(statusVisibility: StatusVisibility) {
+    override fun onVisibilitySelected(statusVisibility: StatusVisibility) {
         _visibility.update { statusVisibility }
     }
 
-    fun onPostClicked() {
+    override fun onPostClicked() {
         analytics.uiEngagement(
             engagementType = EngagementType.POST,
             uiIdentifier = AnalyticsIdentifiers.NEW_POST_POST,

--- a/feature/post/src/main/java/org/mozilla/social/post/poll/PollDelegate.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/poll/PollDelegate.kt
@@ -10,18 +10,19 @@ import org.mozilla.social.core.analytics.EngagementType
 class PollDelegate(
     private val analytics: Analytics,
 ) : PollInteractions {
-    private val _poll = MutableStateFlow<Poll?>(null)
-    val poll = _poll.asStateFlow()
+
+    private val _uiState = MutableStateFlow<PollUiState?>(null)
+    val uiState = _uiState.asStateFlow()
 
     override fun onNewPollClicked() {
         analytics.uiEngagement(
             engagementType = EngagementType.POST,
             uiIdentifier = AnalyticsIdentifiers.NEW_POST_POLL
         )
-        if (poll.value == null) {
-            _poll.value = newPoll()
+        if (uiState.value == null) {
+            _uiState.value = newPoll()
         } else {
-            _poll.value = null
+            _uiState.value = null
         }
     }
 
@@ -30,7 +31,7 @@ class PollDelegate(
         text: String,
     ) {
         if (text.length > MAX_POLL_CHOICE_CHARACTERS) return
-        _poll.edit {
+        _uiState.edit {
             this?.copy(
                 options =
                     options.toMutableList().apply {
@@ -42,7 +43,7 @@ class PollDelegate(
     }
 
     override fun onPollOptionDeleteClicked(optionIndex: Int) {
-        _poll.edit {
+        _uiState.edit {
             this?.copy(
                 options =
                     options.toMutableList().apply {
@@ -53,7 +54,7 @@ class PollDelegate(
     }
 
     override fun onAddPollOptionClicked() {
-        _poll.edit {
+        _uiState.edit {
             this?.copy(
                 options =
                     options.toMutableList().apply {
@@ -64,7 +65,7 @@ class PollDelegate(
     }
 
     override fun onPollDurationSelected(pollDuration: PollDuration) {
-        _poll.edit {
+        _uiState.edit {
             this?.copy(
                 pollDuration = pollDuration,
             )
@@ -72,7 +73,7 @@ class PollDelegate(
     }
 
     override fun onPollStyleSelected(style: PollStyle) {
-        _poll.edit {
+        _uiState.edit {
             this?.copy(
                 style = style,
             )
@@ -80,15 +81,15 @@ class PollDelegate(
     }
 
     override fun onHideCountUntilEndClicked() {
-        _poll.edit {
+        _uiState.edit {
             this?.copy(
                 hideTotals = !hideTotals,
             )
         }
     }
 
-    private fun newPoll(): Poll =
-        Poll(
+    private fun newPoll(): PollUiState =
+        PollUiState(
             options =
                 listOf(
                     "",

--- a/feature/post/src/main/java/org/mozilla/social/post/poll/PollDurationDropdown.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/poll/PollDurationDropdown.kt
@@ -19,7 +19,7 @@ import org.mozilla.social.feature.post.R
 
 @Composable
 fun PollDurationDropDown(
-    poll: Poll,
+    pollUiState: PollUiState,
     pollInteractions: PollInteractions,
 ) {
     val expanded = remember { mutableStateOf(false) }
@@ -36,7 +36,7 @@ fun PollDurationDropDown(
                 fontSize = 12.sp,
             )
             Text(
-                text = poll.pollDuration.label.build(LocalContext.current),
+                text = pollUiState.pollDuration.label.build(LocalContext.current),
             )
         }
     }
@@ -64,8 +64,8 @@ fun PollDurationDropDown(
 private fun PollDurationDropDownPreview() {
     MoSoTheme {
         PollDurationDropDown(
-            poll =
-                Poll(
+            pollUiState =
+                PollUiState(
                     options = listOf("option 1", "option 2"),
                     style = PollStyle.SINGLE_CHOICE,
                     pollDuration = PollDuration.ONE_DAY,

--- a/feature/post/src/main/java/org/mozilla/social/post/poll/PollStyleDropDown.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/poll/PollStyleDropDown.kt
@@ -19,7 +19,7 @@ import org.mozilla.social.feature.post.R
 
 @Composable
 fun PollStyleDropDown(
-    poll: Poll,
+    pollUiState: PollUiState,
     pollInteractions: PollInteractions,
 ) {
     val expanded = remember { mutableStateOf(false) }
@@ -36,7 +36,7 @@ fun PollStyleDropDown(
                 fontSize = 12.sp,
             )
             Text(
-                text = poll.style.label.build(LocalContext.current),
+                text = pollUiState.style.label.build(LocalContext.current),
             )
         }
     }
@@ -64,8 +64,8 @@ fun PollStyleDropDown(
 private fun PollStyleDropDownPreview() {
     MoSoTheme {
         PollStyleDropDown(
-            poll =
-                Poll(
+            pollUiState =
+                PollUiState(
                     options = listOf("option 1", "option 2"),
                     style = PollStyle.SINGLE_CHOICE,
                     pollDuration = PollDuration.ONE_DAY,

--- a/feature/post/src/main/java/org/mozilla/social/post/poll/PollUiState.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/poll/PollUiState.kt
@@ -1,6 +1,6 @@
 package org.mozilla.social.post.poll
 
-data class Poll(
+data class PollUiState(
     val options: List<String>,
     val style: PollStyle,
     val pollDuration: PollDuration,

--- a/feature/post/src/main/java/org/mozilla/social/post/status/StatusDelegate.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/status/StatusDelegate.kt
@@ -23,11 +23,11 @@ import org.mozilla.social.post.NewPostViewModel
 import timber.log.Timber
 
 class StatusDelegate(
-    private val coroutineScope: CoroutineScope,
+    private val analytics: Analytics,
     private val searchRepository: SearchRepository,
     private val statusRepository: StatusRepository,
+    private val coroutineScope: CoroutineScope,
     private val inReplyToId: String?,
-    private val analytics: Analytics,
 ) : StatusInteractions, ContentWarningInteractions {
 
     private val _uiState = MutableStateFlow(StatusUiState())

--- a/feature/post/src/main/java/org/mozilla/social/post/status/StatusUiState.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/status/StatusUiState.kt
@@ -1,0 +1,11 @@
+package org.mozilla.social.post.status
+
+import androidx.compose.ui.text.input.TextFieldValue
+
+data class StatusUiState(
+    val statusText: TextFieldValue = TextFieldValue(""),
+    val accountList: List<Account>? = null,
+    val hashtagList: List<String>? = null,
+    val contentWarningText: String? = null,
+    val inReplyToAccountName: String? = null,
+)


### PR DESCRIPTION
It's been bothering me how many parameters the NewPostScreen has (it was 20), so in this PR I'm working to combine a lot of the parameters into UI state models and doing some other small refactors.

- Creating single UI state models for each of the delegate classes
- injecting the delegates instead of instantiating them (this reduces the parameters required for the view model)
- creating a UI state model for the view model
- Reducing the parameters required for `NewPostScreen` from 20 to 9