### PR TITLE
Fixing various scroll state issues

### DIFF
--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/animation/DelayedVisibility.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/animation/DelayedVisibility.kt
@@ -4,6 +4,9 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,7 +29,11 @@ fun DelayedVisibility(
         enter = fadeIn(
             animationSpec = tween(delayMillis = delay)
         ),
-        exit = fadeOut(),
+        exit = shrinkVertically(
+            animationSpec = tween(durationMillis = 150)
+        ) + fadeOut(
+            animationSpec = tween(durationMillis = 50)
+        ),
     ) {
         content()
     }

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/animation/DelayedVisibility.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/animation/DelayedVisibility.kt
@@ -2,6 +2,7 @@ package org.mozilla.social.core.ui.common.animation
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
@@ -26,7 +27,9 @@ fun DelayedVisibility(
     }
     AnimatedVisibility(
         visible = innerVisible,
-        enter = fadeIn(
+        enter = expandVertically(
+            animationSpec = tween(durationMillis = 0, delayMillis = delay)
+        ) + fadeIn(
             animationSpec = tween(delayMillis = delay)
         ),
         exit = shrinkVertically(

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountScreen.kt
@@ -205,10 +205,20 @@ private fun MainContent(
             Modifier
                 .fillMaxSize(),
     ) {
-        val feedPagingItems = timeline.feed.collectAsLazyPagingItems()
+        val postsFeed = timeline.postsFeed.collectAsLazyPagingItems()
+        val postsAndRepliesFeed = timeline.postsAndRepliesFeed.collectAsLazyPagingItems()
+        val mediaFeed = timeline.mediaFeed.collectAsLazyPagingItems()
+
+        val currentFeed = when (timeline.type) {
+            AccountTimelineType.POSTS -> postsFeed
+            AccountTimelineType.POSTS_AND_REPLIES -> postsAndRepliesFeed
+            AccountTimelineType.MEDIA -> mediaFeed
+        }
+
         val listState = rememberLazyListState()
+
         PagingLazyColumn(
-            lazyPagingItems = feedPagingItems,
+            lazyPagingItems = currentFeed,
             headerContent = {
                 item {
                     MainAccount(
@@ -224,7 +234,7 @@ private fun MainContent(
             emptyListState = listState,
         ) {
             postListContent(
-                lazyPagingItems = feedPagingItems,
+                lazyPagingItems = currentFeed,
                 postCardInteractions = postCardInteractions,
             )
         }
@@ -672,7 +682,9 @@ fun AccountScreenPreview() {
                 isUsersProfile = false,
                 timeline = Timeline(
                     type = AccountTimelineType.POSTS,
-                    feed = flowOf()
+                    postsFeed = flowOf(),
+                    postsAndRepliesFeed = flowOf(),
+                    mediaFeed = flowOf(),
                 ),
                 htmlContentInteractions = object : HtmlContentInteractions {},
                 postCardInteractions = object : PostCardInteractions {},

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountUiState.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountUiState.kt
@@ -33,5 +33,7 @@ data class AccountFieldUiState(
 
 data class Timeline(
     val type: AccountTimelineType,
-    val feed: Flow<PagingData<PostCardUiState>>,
+    val postsFeed: Flow<PagingData<PostCardUiState>>,
+    val postsAndRepliesFeed: Flow<PagingData<PostCardUiState>>,
+    val mediaFeed: Flow<PagingData<PostCardUiState>>,
 )

--- a/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
+++ b/feature/account/src/main/java/org/mozilla/social/feature/account/AccountViewModel.kt
@@ -134,7 +134,14 @@ class AccountViewModel(
         }
     }.cachedIn(viewModelScope)
 
-    private val _timeline = MutableStateFlow(Timeline(AccountTimelineType.POSTS, postsFeed))
+    private val _timeline = MutableStateFlow(
+        Timeline(
+            type = AccountTimelineType.POSTS,
+            postsFeed = postsFeed,
+            postsAndRepliesFeed = postsAndRepliesFeed,
+            mediaFeed = mediaFeed,
+        )
+    )
     val timeline = _timeline.asStateFlow()
 
     init {
@@ -324,32 +331,16 @@ class AccountViewModel(
     }
 
     override fun onTabClicked(timelineType: AccountTimelineType) {
-        _timeline.edit {
-            copy(
-                type = timelineType,
-                feed = when (timelineType) {
-                    AccountTimelineType.POSTS -> {
-                        analytics.uiEngagement(
-                            uiIdentifier = AnalyticsIdentifiers.PROFILE_FEED_POSTS,
-                        )
-                        postsFeed
-                    }
-
-                    AccountTimelineType.POSTS_AND_REPLIES -> {
-                        analytics.uiEngagement(
-                            uiIdentifier = AnalyticsIdentifiers.PROFILE_FEED_POSTS_AND_REPLIES,
-                        )
-                        postsAndRepliesFeed
-                    }
-
-                    AccountTimelineType.MEDIA -> {
-                        analytics.uiEngagement(
-                            uiIdentifier = AnalyticsIdentifiers.PROFILE_FEED_MEDIA,
-                        )
-                        mediaFeed
-                    }
-                }
-            )
+        _timeline.edit { copy(
+            type = timelineType
+        ) }
+        when (timelineType) {
+            AccountTimelineType.POSTS ->
+                analytics.uiEngagement(uiIdentifier = AnalyticsIdentifiers.PROFILE_FEED_POSTS)
+            AccountTimelineType.POSTS_AND_REPLIES ->
+                analytics.uiEngagement(uiIdentifier = AnalyticsIdentifiers.PROFILE_FEED_POSTS_AND_REPLIES,)
+            AccountTimelineType.MEDIA ->
+                analytics.uiEngagement(uiIdentifier = AnalyticsIdentifiers.PROFILE_FEED_MEDIA,)
         }
     }
 

--- a/feature/search/src/main/java/org/mozilla/social/search/SearchScreen.kt
+++ b/feature/search/src/main/java/org/mozilla/social/search/SearchScreen.kt
@@ -2,6 +2,7 @@ package org.mozilla.social.search
 
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -18,7 +19,9 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -231,10 +234,18 @@ private fun ListContent(
             val hashTagFeed = uiState.hashTagFeed?.collectAsLazyPagingItems()
             val statusFeed = uiState.statusFeed?.collectAsLazyPagingItems()
 
+            val topScrollState = rememberLazyListState()
+            val topAccountsScrollState = rememberLazyListState()
+            val accountScrollState = rememberLazyListState()
+            val hashTagScrollState = rememberLazyListState()
+            val statusScrollState = rememberLazyListState()
+
             when (uiState.selectedTab) {
                 SearchTab.TOP -> {
                     TopList(
                         searchResultUiState = uiState.topResource.data,
+                        scrollState = topScrollState,
+                        topAccountsScrollState = topAccountsScrollState,
                         searchInteractions = searchInteractions,
                         postCardInteractions = postCardInteractions,
                     )
@@ -242,18 +253,21 @@ private fun ListContent(
                 SearchTab.ACCOUNTS -> {
                     AccountsList(
                         accountFeed = accountFeed,
+                        scrollState = accountScrollState,
                         searchInteractions = searchInteractions,
                     )
                 }
                 SearchTab.HASHTAGS -> {
                     HashTagsList(
                         hashTagsFeed = hashTagFeed,
+                        scrollState = hashTagScrollState,
                         searchInteractions = searchInteractions,
                     )
                 }
                 SearchTab.POSTS -> {
                     StatusesList(
                         statusFeed = statusFeed,
+                        scrollState = statusScrollState,
                         postCardInteractions = postCardInteractions,
                     )
                 }
@@ -265,17 +279,21 @@ private fun ListContent(
 @Composable
 private fun TopList(
     searchResultUiState: SearchResultUiState,
+    scrollState: LazyListState,
+    topAccountsScrollState: LazyListState,
     searchInteractions: SearchInteractions,
     postCardInteractions: PostCardInteractions,
 ) {
     LazyColumn(
         Modifier
             .fillMaxSize(),
+        state = scrollState,
     ) {
         if (searchResultUiState.accountUiStates.isNotEmpty()) {
             item {
                 TopAccounts(
                     searchResultUiState = searchResultUiState,
+                    scrollState = topAccountsScrollState,
                     searchInteractions = searchInteractions,
                 )
             }
@@ -331,6 +349,7 @@ private fun TopList(
 @Composable
 private fun TopAccounts(
     searchResultUiState: SearchResultUiState,
+    scrollState: LazyListState,
     searchInteractions: SearchInteractions,
 ) {
     Row(
@@ -346,7 +365,9 @@ private fun TopAccounts(
         )
         Icon(painter = MoSoIcons.caretRight(), contentDescription = "")
     }
-    LazyRow {
+    LazyRow(
+        state = scrollState,
+    ) {
         items(
             count = searchResultUiState.accountUiStates.count(),
             key = { searchResultUiState.accountUiStates[it].quickViewUiState.accountId },
@@ -391,12 +412,14 @@ private fun TopAccounts(
 @Composable
 private fun AccountsList(
     accountFeed: LazyPagingItems<AccountFollowerUiState>?,
+    scrollState: LazyListState,
     searchInteractions: SearchInteractions,
 ) {
     accountFeed?.let { lazyPagingItems ->
         PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
-            noResultText = stringResource(id = R.string.search_empty)
+            noResultText = stringResource(id = R.string.search_empty),
+            listState = scrollState,
         ) {
             items(
                 count = lazyPagingItems.itemCount,
@@ -428,12 +451,14 @@ private fun AccountsList(
 @Composable
 private fun StatusesList(
     statusFeed: LazyPagingItems<PostCardUiState>?,
+    scrollState: LazyListState,
     postCardInteractions: PostCardInteractions,
 ) {
     statusFeed?.let { lazyPagingItems ->
         PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
-            noResultText = stringResource(id = R.string.search_empty)
+            noResultText = stringResource(id = R.string.search_empty),
+            listState = scrollState,
         ) {
             postListContent(
                 lazyPagingItems = lazyPagingItems,
@@ -446,12 +471,14 @@ private fun StatusesList(
 @Composable
 private fun HashTagsList(
     hashTagsFeed: LazyPagingItems<HashTagQuickViewUiState>?,
+    scrollState: LazyListState,
     searchInteractions: SearchInteractions,
 ) {
     hashTagsFeed?.let { lazyPagingItems ->
         PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
-            noResultText = stringResource(id = R.string.search_empty)
+            noResultText = stringResource(id = R.string.search_empty),
+            listState = scrollState,
         ) {
             items(
                 count = lazyPagingItems.itemCount,

--- a/feature/search/src/main/java/org/mozilla/social/search/SearchScreen.kt
+++ b/feature/search/src/main/java/org/mozilla/social/search/SearchScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.Flow
@@ -226,6 +227,10 @@ private fun ListContent(
             )
         }
         is Resource.Loaded -> {
+            val accountFeed = uiState.accountsFeed?.collectAsLazyPagingItems()
+            val hashTagFeed = uiState.hashTagFeed?.collectAsLazyPagingItems()
+            val statusFeed = uiState.statusFeed?.collectAsLazyPagingItems()
+
             when (uiState.selectedTab) {
                 SearchTab.TOP -> {
                     TopList(
@@ -236,19 +241,19 @@ private fun ListContent(
                 }
                 SearchTab.ACCOUNTS -> {
                     AccountsList(
-                        accountFeed = uiState.accountsFeed,
+                        accountFeed = accountFeed,
                         searchInteractions = searchInteractions,
                     )
                 }
                 SearchTab.HASHTAGS -> {
                     HashTagsList(
-                        hashTagsFeed = uiState.hashTagFeed,
+                        hashTagsFeed = hashTagFeed,
                         searchInteractions = searchInteractions,
                     )
                 }
                 SearchTab.POSTS -> {
                     StatusesList(
-                        statusFeed = uiState.statusFeed,
+                        statusFeed = statusFeed,
                         postCardInteractions = postCardInteractions,
                     )
                 }
@@ -385,10 +390,10 @@ private fun TopAccounts(
 
 @Composable
 private fun AccountsList(
-    accountFeed: Flow<PagingData<AccountFollowerUiState>>?,
+    accountFeed: LazyPagingItems<AccountFollowerUiState>?,
     searchInteractions: SearchInteractions,
 ) {
-    accountFeed?.collectAsLazyPagingItems()?.let { lazyPagingItems ->
+    accountFeed?.let { lazyPagingItems ->
         PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
             noResultText = stringResource(id = R.string.search_empty)
@@ -422,10 +427,10 @@ private fun AccountsList(
 
 @Composable
 private fun StatusesList(
-    statusFeed: Flow<PagingData<PostCardUiState>>?,
+    statusFeed: LazyPagingItems<PostCardUiState>?,
     postCardInteractions: PostCardInteractions,
 ) {
-    statusFeed?.collectAsLazyPagingItems()?.let { lazyPagingItems ->
+    statusFeed?.let { lazyPagingItems ->
         PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
             noResultText = stringResource(id = R.string.search_empty)
@@ -440,10 +445,10 @@ private fun StatusesList(
 
 @Composable
 private fun HashTagsList(
-    hashTagsFeed: Flow<PagingData<HashTagQuickViewUiState>>?,
+    hashTagsFeed: LazyPagingItems<HashTagQuickViewUiState>?,
     searchInteractions: SearchInteractions,
 ) {
-    hashTagsFeed?.collectAsLazyPagingItems()?.let { lazyPagingItems ->
+    hashTagsFeed?.let { lazyPagingItems ->
         PagingLazyColumn(
             lazyPagingItems = lazyPagingItems,
             noResultText = stringResource(id = R.string.search_empty)


### PR DESCRIPTION
- Fixing issues with account scroll states
  - Loading all three account post tabs right away
  - Fixing issues with empty tabs
- Fixing issues with search scroll states
  - Loading all tabs right away
  - Separating scroll states so they are remembered when switching between tabs