### PR TITLE
New post hashtag and account issues

### DIFF
--- a/core/common/src/main/java/org/mozilla/social/common/utils/TextFieldValueExtensions.kt
+++ b/core/common/src/main/java/org/mozilla/social/common/utils/TextFieldValueExtensions.kt
@@ -6,32 +6,37 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
+import kotlin.math.min
 
 /**
  * @return the account string a user is typing if they are typing one, otherwise null
  */
-fun TextFieldValue.accountText(): String? = findSymbolText('@')
+fun TextFieldValue.accountText(): String? = findSymbolTextAtCursor('@')
 
 /**
  * @return the hashtag string a user is typing if they are typing one, otherwise null
  */
-fun TextFieldValue.hashtagText(): String? = findSymbolText('#')
+fun TextFieldValue.hashtagText(): String? = findSymbolTextAtCursor('#')
 
 /**
  * @return the string between a symbol and the cursor a user is typing if they are typing one, otherwise null
  */
-fun TextFieldValue.findSymbolText(symbol: Char): String? {
+fun TextFieldValue.findSymbolTextAtCursor(symbol: Char): String? {
     if (!text.contains(symbol) || selection.start != selection.end) return null
-    val firstSpaceIndexAfterCursor = text.indexOf(' ', startIndex = selection.end)
+
+    val firstSpaceOrNewLineIndexAfterCursor = getFirstSpaceOrNewLineIndexAfterCursor(
+        text = text,
+        cursorIndex = selection.end,
+    )
     val textBeforeSpaceOrEnd =
-        if (firstSpaceIndexAfterCursor != -1) {
-            text.substring(0, firstSpaceIndexAfterCursor)
+        if (firstSpaceOrNewLineIndexAfterCursor != -1) {
+            text.substring(0, firstSpaceOrNewLineIndexAfterCursor)
         } else {
             text
         }
     if (!textBeforeSpaceOrEnd.contains(symbol)) return null
     val textBetweenSymbolAndCursor = textBeforeSpaceOrEnd.substringAfterLast(symbol)
-    return if (!textBetweenSymbolAndCursor.contains(" ")) {
+    return if (!textBetweenSymbolAndCursor.contains(' ') && !textBetweenSymbolAndCursor.contains('\n')) {
         textBetweenSymbolAndCursor
     } else {
         null
@@ -47,29 +52,39 @@ fun TextFieldValue.replaceSymbolText(
     newText: String,
 ): TextFieldValue {
     if (!text.contains(symbol)) return this
-    val firstSpaceIndexAfterCursor = text.indexOf(' ', startIndex = selection.end)
+    val firstSpaceOrNewLineIndexAfterCursor = getFirstSpaceOrNewLineIndexAfterCursor(
+        text = text,
+        cursorIndex = selection.end,
+    )
     val textBeforeSpaceOrEnd =
-        if (firstSpaceIndexAfterCursor != -1) {
-            text.substring(0, firstSpaceIndexAfterCursor)
+        if (firstSpaceOrNewLineIndexAfterCursor != -1) {
+            text.substring(0, firstSpaceOrNewLineIndexAfterCursor)
         } else {
             text
         }
     if (!textBeforeSpaceOrEnd.contains(symbol) ||
-        textBeforeSpaceOrEnd.substringAfterLast(symbol).contains(" ")
+        textBeforeSpaceOrEnd.substringAfterLast(symbol).contains(' ') ||
+        textBeforeSpaceOrEnd.substringAfterLast(symbol).contains('\n')
     ) {
         return this
     }
     val rangeStart = textBeforeSpaceOrEnd.lastIndexOf(symbol) + 1
     val rangeEnd =
-        if (firstSpaceIndexAfterCursor != -1) {
-            firstSpaceIndexAfterCursor
+        if (firstSpaceOrNewLineIndexAfterCursor != -1) {
+            firstSpaceOrNewLineIndexAfterCursor
         } else {
             text.length - 1
         }
+    // if there is a newline at the end, make sure to add it back in
+    val finalChar = if (text[rangeEnd] == '\n') {
+        '\n'
+    } else {
+        ""
+    }
     val finalText =
         text.replaceRange(
             rangeStart..rangeEnd,
-            "$newText ",
+            "$newText $finalChar",
         )
     return copy(
         text = finalText,
@@ -91,7 +106,8 @@ fun buildAnnotatedStringWithSymbols(
         var searchingForSymbol = true // if false then we are searching for a space
         text.forEachIndexed { index, character ->
             if (searchingForSymbol) {
-                if ((index == 0 || text[index - 1] == ' ') && symbols.contains(character)) {
+                val isStartOfWord = index == 0 || text[index - 1] == ' ' || text[index - 1] == '\n'
+                if (isStartOfWord && symbols.contains(character)) {
                     withStyle(style) {
                         append(character)
                     }
@@ -103,10 +119,27 @@ fun buildAnnotatedStringWithSymbols(
                 withStyle(style) {
                     append(character)
                 }
-                if (character == ' ') {
+                if (character == ' ' || character == '\n') {
                     searchingForSymbol = true
                 }
             }
         }
+    }
+}
+
+private fun getFirstSpaceOrNewLineIndexAfterCursor(
+    text: String,
+    cursorIndex: Int,
+): Int {
+    val firstSpaceIndexAfterCursor = text.indexOf(' ', startIndex = cursorIndex)
+    val firstNewLineIndexAfterCursor = text.indexOf('\n', startIndex = cursorIndex)
+
+    return when {
+        firstSpaceIndexAfterCursor == -1 -> firstNewLineIndexAfterCursor
+        firstNewLineIndexAfterCursor == -1 -> firstSpaceIndexAfterCursor
+        else -> min(
+            firstSpaceIndexAfterCursor,
+            firstNewLineIndexAfterCursor
+        )
     }
 }

--- a/core/common/src/main/java/org/mozilla/social/common/utils/TextFieldValueExtensions.kt
+++ b/core/common/src/main/java/org/mozilla/social/common/utils/TextFieldValueExtensions.kt
@@ -11,12 +11,12 @@ import kotlin.math.min
 /**
  * @return the account string a user is typing if they are typing one, otherwise null
  */
-fun TextFieldValue.accountText(): String? = findSymbolTextAtCursor('@')
+fun TextFieldValue.findAccountAtCursor(): String? = findSymbolTextAtCursor('@')
 
 /**
  * @return the hashtag string a user is typing if they are typing one, otherwise null
  */
-fun TextFieldValue.hashtagText(): String? = findSymbolTextAtCursor('#')
+fun TextFieldValue.findHashtagAtCursor(): String? = findSymbolTextAtCursor('#')
 
 /**
  * @return the string between a symbol and the cursor a user is typing if they are typing one, otherwise null
@@ -43,11 +43,23 @@ fun TextFieldValue.findSymbolTextAtCursor(symbol: Char): String? {
     }
 }
 
-fun TextFieldValue.replaceAccount(newText: String): TextFieldValue = replaceSymbolText('@', newText)
+fun TextFieldValue.replaceAccount(newText: String): TextFieldValue = replaceTextAfterSymbolAtCursor('@', newText)
 
-fun TextFieldValue.replaceHashtag(newText: String): TextFieldValue = replaceSymbolText('#', newText)
+fun TextFieldValue.replaceHashtag(newText: String): TextFieldValue = replaceTextAfterSymbolAtCursor('#', newText)
 
-fun TextFieldValue.replaceSymbolText(
+/**
+ * Copies the [TextFieldValue] and replaces the text after the symbol with the new text.
+ * For example, if your text field value looks like this:
+ * "I like #appl"
+ * And your cursor is right after the '#' character, and your new text is "apples", then the
+ * new text value of [TextFieldValue] will be:
+ * "I like #apples"
+ *
+ * @param symbol the symbol that acts as a starting position for replacing text
+ * @param newText the text that will replace the current text that is directly after the symbol
+ * @return a copy of the [TextFieldValue] with the replaced text
+ */
+fun TextFieldValue.replaceTextAfterSymbolAtCursor(
     symbol: Char,
     newText: String,
 ): TextFieldValue {
@@ -97,6 +109,20 @@ fun buildAnnotatedStringForAccountsAndHashtags(
     style: SpanStyle,
 ): AnnotatedString = buildAnnotatedStringWithSymbols(listOf('@', '#'), baseText, style)
 
+/**
+ * Styles a string based on a list of symbols.  The style will be applied to the symbols and
+ * the text directly following the symbols.
+ *
+ * For example, if you want to style hashtags, you include '#' in your symbols list.
+ * Then, if you text is:
+ * "I like #apples"
+ * The style will be applied to "#apples"
+ *
+ * @param symbols list of symbols you want your styled text to start with
+ * @param text the text you are styling
+ * @param style the style to be applied to the symbolized text
+ * @return an [AnnotatedString] with the applied style
+ */
 fun buildAnnotatedStringWithSymbols(
     symbols: List<Char>,
     text: String,
@@ -127,6 +153,9 @@ fun buildAnnotatedStringWithSymbols(
     }
 }
 
+/**
+ * @return the index of the first space or new line in the string that comes after the cursorIndex
+ */
 private fun getFirstSpaceOrNewLineIndexAfterCursor(
     text: String,
     cursorIndex: Int,

--- a/core/common/src/test/java/org/mozilla/social/common/utils/TextFieldValueExtensionsTest.kt
+++ b/core/common/src/test/java/org/mozilla/social/common/utils/TextFieldValueExtensionsTest.kt
@@ -13,63 +13,63 @@ class TextFieldValueExtensionsTest {
                 text = "@test",
                 selection = TextRange(3),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test",
                 selection = TextRange(0),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test",
                 selection = TextRange(5),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test ",
                 selection = TextRange(6),
             )
-        assertEquals(null, textFieldValue.accountText())
+        assertEquals(null, textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = " @test",
                 selection = TextRange(0),
             )
-        assertEquals(null, textFieldValue.accountText())
+        assertEquals(null, textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(0),
             )
-        assertEquals(null, textFieldValue.accountText())
+        assertEquals(null, textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(3),
             )
-        assertEquals(null, textFieldValue.accountText())
+        assertEquals(null, textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(4),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test bar",
                 selection = TextRange(6),
             )
-        assertEquals(null, textFieldValue.accountText())
+        assertEquals(null, textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
@@ -78,7 +78,7 @@ class TextFieldValueExtensionsTest {
                         "lala",
                 selection = TextRange(3),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
@@ -87,7 +87,7 @@ class TextFieldValueExtensionsTest {
                         "lala",
                 selection = TextRange(2),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
 
         textFieldValue =
             TextFieldValue(
@@ -96,7 +96,7 @@ class TextFieldValueExtensionsTest {
                         "@test",
                 selection = TextRange(9),
             )
-        assertEquals("test", textFieldValue.accountText())
+        assertEquals("test", textFieldValue.findAccountAtCursor())
     }
 
     @Test

--- a/core/common/src/test/java/org/mozilla/social/common/utils/TextFieldValueExtensionsTest.kt
+++ b/core/common/src/test/java/org/mozilla/social/common/utils/TextFieldValueExtensionsTest.kt
@@ -3,6 +3,7 @@ package org.mozilla.social.common.utils
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class TextFieldValueExtensionsTest {
     @Test
@@ -12,63 +13,90 @@ class TextFieldValueExtensionsTest {
                 text = "@test",
                 selection = TextRange(3),
             )
-        assert(textFieldValue.accountText() == "test")
+        assertEquals("test", textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test",
                 selection = TextRange(0),
             )
-        assert(textFieldValue.accountText() == "test")
+        assertEquals("test", textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test",
                 selection = TextRange(5),
             )
-        assert(textFieldValue.accountText() == "test")
+        assertEquals("test", textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test ",
                 selection = TextRange(6),
             )
-        assert(textFieldValue.accountText() == null)
+        assertEquals(null, textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = " @test",
                 selection = TextRange(0),
             )
-        assert(textFieldValue.accountText() == null)
+        assertEquals(null, textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(0),
             )
-        assert(textFieldValue.accountText() == null)
+        assertEquals(null, textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(3),
             )
-        assert(textFieldValue.accountText() == null)
+        assertEquals(null, textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(4),
             )
-        assert(textFieldValue.accountText() == "test")
+        assertEquals("test", textFieldValue.accountText())
 
         textFieldValue =
             TextFieldValue(
                 text = "@test bar",
                 selection = TextRange(6),
             )
-        assert(textFieldValue.accountText() == null)
+        assertEquals(null, textFieldValue.accountText())
+
+        textFieldValue =
+            TextFieldValue(
+                text = "@test\n" +
+                        "\n" +
+                        "lala",
+                selection = TextRange(3),
+            )
+        assertEquals("test", textFieldValue.accountText())
+
+        textFieldValue =
+            TextFieldValue(
+                text = "@test \n" +
+                        "\n" +
+                        "lala",
+                selection = TextRange(2),
+            )
+        assertEquals("test", textFieldValue.accountText())
+
+        textFieldValue =
+            TextFieldValue(
+                text = "lala\n" +
+                        "\n" +
+                        "@test",
+                selection = TextRange(9),
+            )
+        assertEquals("test", textFieldValue.accountText())
     }
 
     @Test
@@ -78,69 +106,97 @@ class TextFieldValueExtensionsTest {
                 text = "@test",
                 selection = TextRange(0),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "@new ")
+        assertEquals("@new ", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "@test",
                 selection = TextRange(2),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "@new ")
+        assertEquals("@new ", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "@test",
                 selection = TextRange(5),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "@new ")
+        assertEquals("@new ", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "@test ",
                 selection = TextRange(6),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "@test ")
+        assertEquals("@test ", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = " @test",
                 selection = TextRange(3),
             ).replaceAccount("new")
-        assert(textFieldValue.text == " @new ")
+        assertEquals(" @new ", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = " @test",
                 selection = TextRange(0),
             ).replaceAccount("new")
-        assert(textFieldValue.text == " @test")
+        assertEquals(" @test", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(3),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "foo @test")
+        assertEquals("foo @test", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test",
                 selection = TextRange(4),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "foo @new ")
+        assertEquals("foo @new ", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test bar",
                 selection = TextRange(9),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "foo @new bar")
+        assertEquals("foo @new bar", textFieldValue.text)
 
         textFieldValue =
             TextFieldValue(
                 text = "foo @test bar",
                 selection = TextRange(10),
             ).replaceAccount("new")
-        assert(textFieldValue.text == "foo @test bar")
+        assertEquals("foo @test bar", textFieldValue.text)
+
+        textFieldValue =
+            TextFieldValue(
+                text = "foo\n" +
+                        "@test\n" +
+                        "bar",
+                selection = TextRange(9),
+            ).replaceAccount("new")
+        assertEquals(
+            "foo\n" +
+                    "@new \n" +
+                    "bar",
+            textFieldValue.text
+        )
+
+        textFieldValue =
+            TextFieldValue(
+                text = "foo\n" +
+                        "@test\n" +
+                        "bar",
+                selection = TextRange(10),
+            ).replaceAccount("new")
+        assertEquals(
+            "foo\n" +
+                    "@test\n" +
+                    "bar",
+            textFieldValue.text
+        )
     }
 }

--- a/feature/post/src/main/java/org/mozilla/social/post/status/StatusDelegate.kt
+++ b/feature/post/src/main/java/org/mozilla/social/post/status/StatusDelegate.kt
@@ -7,11 +7,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.mozilla.social.common.utils.accountText
+import org.mozilla.social.common.utils.findAccountAtCursor
 import org.mozilla.social.common.utils.edit
-import org.mozilla.social.common.utils.hashtagText
+import org.mozilla.social.common.utils.findHashtagAtCursor
 import org.mozilla.social.common.utils.replaceAccount
 import org.mozilla.social.common.utils.replaceHashtag
 import org.mozilla.social.core.analytics.Analytics
@@ -66,14 +65,14 @@ class StatusDelegate(
     private fun searchForAccountsAndHashtags(textFieldValue: TextFieldValue) {
         searchJob?.cancel()
 
-        val accountText = textFieldValue.accountText()
+        val accountText = textFieldValue.findAccountAtCursor()
         if (accountText.isNullOrBlank()) {
             _uiState.edit { copy(
                 accountList = null
             ) }
         }
 
-        val hashtagText = textFieldValue.hashtagText()
+        val hashtagText = textFieldValue.findHashtagAtCursor()
         if (hashtagText.isNullOrBlank()) {
             _uiState.edit { copy(
                 hashtagList = null


### PR DESCRIPTION
There were bugs with highlighting, searching, and replacing hashtags and accounts in the new post screen.  The bugs stemmed from the algorithm not taking into consideration new line characters.

- fixed issues with highlighting, searching, and replacing hashtags and accounts
- added some extra unit tests