### PR TITLE
Fixing tab issue

### DIFF
--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/MoSoTab.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/MoSoTab.kt
@@ -1,20 +1,52 @@
 package org.mozilla.social.core.ui.common
 
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabPosition
 import androidx.compose.material3.TabRow
-import androidx.compose.material3.TabRowDefaults
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.mozilla.social.core.designsystem.theme.MoSoTheme
+import org.mozilla.social.core.ui.common.TabRowDefaults.tabIndicatorOffset
 import org.mozilla.social.core.ui.common.divider.MoSoDivider
+import org.mozilla.social.core.ui.common.utils.getMaxWidthInt
 
 @Composable
 fun MoSoTabRow(
@@ -35,16 +67,264 @@ fun MoSoTabRow(
     },
     tabs: @Composable () -> Unit,
 ) {
-    TabRow(
-        selectedTabIndex = selectedTabIndex,
+    Surface(
         modifier = modifier,
-        containerColor = containerColor,
-        contentColor = contentColor,
-        indicator = indicator,
-        divider = divider,
-        tabs = tabs,
-    )
+        color = containerColor,
+        contentColor = contentColor
+    ) {
+        val scrollState = rememberScrollState()
+        val coroutineScope = rememberCoroutineScope()
+        val scrollableTabData = remember(scrollState, coroutineScope) {
+            ScrollableTabData(
+                scrollState = scrollState,
+                coroutineScope = coroutineScope
+            )
+        }
+        val maxWidth = getMaxWidthInt()
+
+        SubcomposeLayout(
+            Modifier
+                .fillMaxWidth()
+                .wrapContentSize(align = Alignment.CenterStart)
+                .horizontalScroll(scrollState)
+                .selectableGroup()
+                .clipToBounds()
+        ) { constraints ->
+            var minTabWidth = ScrollableTabRowMinimumTabWidth.roundToPx()
+
+            val tabMeasurables = subcompose(TabSlots.Tabs, tabs)
+
+            val tabsWidth = tabMeasurables.sumOf { it.maxIntrinsicWidth(Constraints.Infinity) }
+
+            if (tabsWidth < maxWidth) {
+                minTabWidth = maxWidth / tabMeasurables.size
+            }
+
+            val layoutHeight = tabMeasurables.fold(initial = 0) { curr, measurable ->
+                maxOf(curr, measurable.maxIntrinsicHeight(Constraints.Infinity))
+            }
+
+            val tabConstraints = constraints.copy(
+                minWidth = minTabWidth,
+                minHeight = layoutHeight,
+                maxHeight = layoutHeight,
+            )
+            val tabPlaceables = tabMeasurables
+                .map { it.measure(tabConstraints) }
+
+            val layoutWidth = tabPlaceables.fold(initial = 0) { curr, measurable ->
+                curr + measurable.width
+            }
+
+            // Position the children.
+            layout(layoutWidth, layoutHeight) {
+                // Place the tabs
+                val tabPositions = mutableListOf<TabPosition>()
+                var left = 0
+                tabPlaceables.forEach {
+                    it.placeRelative(left, 0)
+                    tabPositions.add(TabPosition(left = left.toDp(), width = it.width.toDp()))
+                    left += it.width
+                }
+
+                // The divider is measured with its own height, and width equal to the total width
+                // of the tab row, and then placed on top of the tabs.
+                subcompose(TabSlots.Divider, divider).forEach {
+                    val placeable = it.measure(
+                        constraints.copy(
+                            minHeight = 0,
+                            minWidth = layoutWidth,
+                            maxWidth = layoutWidth
+                        )
+                    )
+                    placeable.placeRelative(0, layoutHeight - placeable.height)
+                }
+
+                // The indicator container is measured to fill the entire space occupied by the tab
+                // row, and then placed on top of the divider.
+                subcompose(TabSlots.Indicator) {
+                    indicator(tabPositions)
+                }.forEach {
+                    it.measure(Constraints.fixed(layoutWidth, layoutHeight)).placeRelative(0, 0)
+                }
+
+                scrollableTabData.onLaidOut(
+                    density = this@SubcomposeLayout,
+                    edgeOffset = 0,
+                    tabPositions = tabPositions,
+                    selectedTab = selectedTabIndex
+                )
+            }
+        }
+    }
 }
+
+/**
+ * Data class that contains information about a tab's position on screen, used for calculating
+ * where to place the indicator that shows which tab is selected.
+ *
+ * @property left the left edge's x position from the start of the [TabRow]
+ * @property right the right edge's x position from the start of the [TabRow]
+ * @property width the width of this tab
+ */
+@Immutable
+class TabPosition internal constructor(val left: Dp, val width: Dp) {
+    val right: Dp get() = left + width
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TabPosition) return false
+
+        if (left != other.left) return false
+        if (width != other.width) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = left.hashCode()
+        result = 31 * result + width.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TabPosition(left=$left, right=$right, width=$width)"
+    }
+}
+
+/**
+ * Contains default implementations and values used for TabRow.
+ */
+object TabRowDefaults {
+    /** Default content color of a tab row. */
+    val contentColor: Color @Composable get() =
+        MoSoTheme.colors.layer1
+
+    /**
+     * Default indicator, which will be positioned at the bottom of the [TabRow], on top of the
+     * divider.
+     *
+     * @param modifier modifier for the indicator's layout
+     * @param height height of the indicator
+     * @param color color of the indicator
+     */
+    @Composable
+    fun Indicator(
+        modifier: Modifier = Modifier,
+        height: Dp = 3.dp,
+        color: Color = MoSoTheme.colors.layer1
+    ) {
+        Box(
+            modifier
+                .fillMaxWidth()
+                .height(height)
+                .background(color = color)
+        )
+    }
+
+    /**
+     * [Modifier] that takes up all the available width inside the [TabRow], and then animates
+     * the offset of the indicator it is applied to, depending on the [currentTabPosition].
+     *
+     * @param currentTabPosition [TabPosition] of the currently selected tab. This is used to
+     * calculate the offset of the indicator this modifier is applied to, as well as its width.
+     */
+    fun Modifier.tabIndicatorOffset(
+        currentTabPosition: TabPosition
+    ): Modifier = composed(
+        inspectorInfo = debugInspectorInfo {
+            name = "tabIndicatorOffset"
+            value = currentTabPosition
+        }
+    ) {
+        val currentTabWidth by animateDpAsState(
+            targetValue = currentTabPosition.width,
+            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+        )
+        val indicatorOffset by animateDpAsState(
+            targetValue = currentTabPosition.left,
+            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+        )
+        fillMaxWidth()
+            .wrapContentSize(Alignment.BottomStart)
+            .offset(x = indicatorOffset)
+            .width(currentTabWidth)
+    }
+}
+
+private enum class TabSlots {
+    Tabs,
+    Divider,
+    Indicator
+}
+
+/**
+ * Class holding onto state needed for [ScrollableTabRow]
+ */
+private class ScrollableTabData(
+    private val scrollState: ScrollState,
+    private val coroutineScope: CoroutineScope
+) {
+    private var selectedTab: Int? = null
+
+    fun onLaidOut(
+        density: Density,
+        edgeOffset: Int,
+        tabPositions: List<TabPosition>,
+        selectedTab: Int
+    ) {
+        // Animate if the new tab is different from the old tab, or this is called for the first
+        // time (i.e selectedTab is `null`).
+        if (this.selectedTab != selectedTab) {
+            this.selectedTab = selectedTab
+            tabPositions.getOrNull(selectedTab)?.let {
+                // Scrolls to the tab with [tabPosition], trying to place it in the center of the
+                // screen or as close to the center as possible.
+                val calculatedOffset = it.calculateTabOffset(density, edgeOffset, tabPositions)
+                if (scrollState.value != calculatedOffset) {
+                    coroutineScope.launch {
+                        scrollState.animateScrollTo(
+                            calculatedOffset,
+                            animationSpec = ScrollableTabRowScrollSpec
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @return the offset required to horizontally center the tab inside this TabRow.
+     * If the tab is at the start / end, and there is not enough space to fully centre the tab, this
+     * will just clamp to the min / max position given the max width.
+     */
+    private fun TabPosition.calculateTabOffset(
+        density: Density,
+        edgeOffset: Int,
+        tabPositions: List<TabPosition>
+    ): Int = with(density) {
+        val totalTabRowWidth = tabPositions.last().right.roundToPx() + edgeOffset
+        val visibleWidth = totalTabRowWidth - scrollState.maxValue
+        val tabOffset = left.roundToPx()
+        val scrollerCenter = visibleWidth / 2
+        val tabWidth = width.roundToPx()
+        val centeredTabOffset = tabOffset - (scrollerCenter - tabWidth / 2)
+        // How much space we have to scroll. If the visible width is <= to the total width, then
+        // we have no space to scroll as everything is always visible.
+        val availableSpace = (totalTabRowWidth - visibleWidth).coerceAtLeast(0)
+        return centeredTabOffset.coerceIn(0, availableSpace)
+    }
+}
+
+private val ScrollableTabRowMinimumTabWidth = 90.dp
+
+/**
+ * [AnimationSpec] used when scrolling to a tab that is not fully visible.
+ */
+private val ScrollableTabRowScrollSpec: AnimationSpec<Float> = tween(
+    durationMillis = 250,
+    easing = FastOutSlowInEasing
+)
 
 @Composable
 fun MoSoTab(
@@ -55,6 +335,7 @@ fun MoSoTab(
     selectedContentColor: Color = MoSoTheme.colors.textLink,
     unselectedContentColor: Color = MoSoTheme.colors.textPrimary,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    contentPadding: Dp = 16.dp,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Tab(
@@ -65,7 +346,11 @@ fun MoSoTab(
         selectedContentColor = selectedContentColor,
         unselectedContentColor = unselectedContentColor,
         interactionSource = interactionSource,
-        content = content,
+        content = {
+            Column(modifier = Modifier.padding(horizontal = contentPadding)) {
+                content()
+            }
+        },
     )
 }
 

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/utils/MaxWidthFinder.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/utils/MaxWidthFinder.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -31,21 +30,6 @@ fun getMaxWidth(): Dp {
                         maxWidth = it.width.toDp()
                     }
                 },
-    )
-    return maxWidth
-}
-
-@Composable
-fun getMaxWidthInt(): Int {
-    var maxWidth by remember { mutableIntStateOf(0) }
-
-    Box(
-        modifier =
-        Modifier
-            .fillMaxWidth()
-            .onSizeChanged {
-                maxWidth = it.width
-            },
     )
     return maxWidth
 }

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/utils/MaxWidthFinder.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/utils/MaxWidthFinder.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -30,6 +31,21 @@ fun getMaxWidth(): Dp {
                         maxWidth = it.width.toDp()
                     }
                 },
+    )
+    return maxWidth
+}
+
+@Composable
+fun getMaxWidthInt(): Int {
+    var maxWidth by remember { mutableIntStateOf(0) }
+
+    Box(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .onSizeChanged {
+                maxWidth = it.width
+            },
     )
     return maxWidth
 }


### PR DESCRIPTION
Tabs on smaller devices might have text that expands to two lines, like here https://github.com/MozillaSocial/mozilla-social-android/issues/419

This could also happen when we add in localization.

One possible solution would be to use the material3 `ScrollableTabRow`.  However, this looks bad when the tabs don't take up the entire space, because they are all squished in the middle or to the side.

My solution here is to copy `ScrollableTabRow` to our code and modify it so that minimum tab widths are dynamically calculated.  This makes it so that if your screen is big enough, the tabs look exactly as they do already, but if your screen is too small, you can scroll the tabs.

### Before

![1706482215_grim](https://github.com/MozillaSocial/mozilla-social-android/assets/14130581/dd1982cd-f905-4648-82d8-ca77e97379a1)

### After

![1706482174_grim](https://github.com/MozillaSocial/mozilla-social-android/assets/14130581/1e4e46ad-6f14-40c2-844d-3e2bd80ada57)

