### PR TITLE
Search double tap

### DIFF
--- a/app/src/main/java/org/mozilla/social/ui/bottombar/BottomBarTabs.kt
+++ b/app/src/main/java/org/mozilla/social/ui/bottombar/BottomBarTabs.kt
@@ -33,6 +33,7 @@ enum class BottomBarTabs(
                 override val tabText = StringFactory.resource(R.string.feed_tab_text)
                 override val navigationDestination: Destination =
                     Destination.BottomBar(BottomBarNavigationDestination.Feed)
+                override val doubleTapDestination: Destination? = null
             },
     ),
     DISCOVER(
@@ -51,6 +52,8 @@ enum class BottomBarTabs(
                 override val tabText = StringFactory.resource(R.string.discover_tab_text)
                 override val navigationDestination: Destination =
                     Destination.BottomBar(BottomBarNavigationDestination.Discover)
+                override val doubleTapDestination: Destination =
+                    Destination.Main(NavigationDestination.Search)
             },
     ),
     NEW_POST(
@@ -69,6 +72,7 @@ enum class BottomBarTabs(
                 override val tabText = StringFactory.resource(R.string.new_post_tab_text)
                 override val navigationDestination: Destination =
                     Destination.Main(NavigationDestination.NewPost())
+                override val doubleTapDestination: Destination? = null
             },
     ),
     NOTIFICATIONS(
@@ -87,6 +91,7 @@ enum class BottomBarTabs(
                 override val tabText = StringFactory.resource(R.string.notifications_tab_text)
                 override val navigationDestination: Destination =
                     Destination.BottomBar(BottomBarNavigationDestination.Notifications)
+                override val doubleTapDestination: Destination? = null
             },
     ),
     ACCOUNT(
@@ -105,6 +110,7 @@ enum class BottomBarTabs(
                 override val tabText = StringFactory.resource(R.string.account_tab_text)
                 override val navigationDestination: Destination =
                     Destination.BottomBar(BottomBarNavigationDestination.MyAccount)
+                override val doubleTapDestination: Destination? = null
             },
     ),
 }

--- a/app/src/main/java/org/mozilla/social/ui/bottombar/MoSoNavigationBar.kt
+++ b/app/src/main/java/org/mozilla/social/ui/bottombar/MoSoNavigationBar.kt
@@ -184,6 +184,7 @@ interface BottomBarTab {
 
     val tabText: StringFactory
     val navigationDestination: Destination
+    // Destination for when the user taps the icon a second time
     val doubleTapDestination: Destination?
 }
 

--- a/app/src/main/java/org/mozilla/social/ui/bottombar/MoSoNavigationBar.kt
+++ b/app/src/main/java/org/mozilla/social/ui/bottombar/MoSoNavigationBar.kt
@@ -111,11 +111,11 @@ private fun MoSoNavigationBar(
     ) {
         Row(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .windowInsetsPadding(windowInsets)
-                    .height(height)
-                    .selectableGroup(),
+            Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(windowInsets)
+                .height(height)
+                .selectableGroup(),
             horizontalArrangement = Arrangement.SpaceEvenly,
             content = content,
         )
@@ -133,7 +133,13 @@ private fun RowScope.MoSoNavigationBarItem(
         modifier = modifier
             .height(48.dp),
         selected = isSelected,
-        onClick = { navigateTo(destination.navigationDestination) },
+        onClick = {
+            if (isSelected) {
+                destination.doubleTapDestination?.let { destination -> navigateTo(destination) }
+            } else {
+                navigateTo(destination.navigationDestination)
+            }
+        },
         colors = MoSoNavigationBarItemDefaults.colors(),
         icon = {
             BottomBarIcon(
@@ -178,6 +184,7 @@ interface BottomBarTab {
 
     val tabText: StringFactory
     val navigationDestination: Destination
+    val doubleTapDestination: Destination?
 }
 
 /**

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/search/MoSoSearchBar.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/search/MoSoSearchBar.kt
@@ -76,7 +76,7 @@ fun MoSoSearchBar(
         BasicTextField(
             value = query,
             modifier = modifier
-                .defaultMinSize(minHeight = 40.dp)
+                .height(42.dp)
                 .border(
                     width = 1.dp,
                     color =

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/search/MoSoSearchBar.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/search/MoSoSearchBar.kt
@@ -3,6 +3,7 @@ package org.mozilla.social.core.ui.common.search
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -75,7 +76,7 @@ fun MoSoSearchBar(
         BasicTextField(
             value = query,
             modifier = modifier
-                .height(36.dp)
+                .defaultMinSize(minHeight = 40.dp)
                 .border(
                     width = 1.dp,
                     color =

--- a/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/java/org/mozilla/social/feature/discover/DiscoverScreen.kt
@@ -19,12 +19,14 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
@@ -46,6 +48,7 @@ import org.mozilla.social.core.designsystem.theme.MoSoTheme
 import org.mozilla.social.core.designsystem.utils.NoRipple
 import org.mozilla.social.core.model.Recommendation
 import org.mozilla.social.core.ui.common.MoSoSurface
+import org.mozilla.social.core.ui.common.appbar.MoSoTopBar
 import org.mozilla.social.core.ui.common.divider.MoSoDivider
 import org.mozilla.social.core.ui.common.error.GenericError
 import org.mozilla.social.core.ui.common.loading.MaxSizeLoading
@@ -67,6 +70,7 @@ internal fun DiscoverScreen(viewModel: DiscoverViewModel = koinViewModel()) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DiscoverScreen(
     recommendations: Resource<List<Recommendation>>,
@@ -80,20 +84,20 @@ private fun DiscoverScreen(
         Column {
             Box(
                 modifier = Modifier
-                    .padding(
-                        start = MoSoSpacing.md,
-                        end = MoSoSpacing.md,
-                        // 14 on top should make the search bar align perfectly with the
-                        // search bar on the search screen
-                        top = 14.dp,
-                        bottom = MoSoSpacing.md,
-                    )
                     .fillMaxWidth()
                     .height(IntrinsicSize.Max),
             ) {
+                // Adding an empty top bar ensure the search bar will align with the
+                // search bar on the search screen
+                MoSoTopBar(title = { })
                 MoSoSearchBar(
                     modifier = Modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .align(Alignment.CenterEnd)
+                        .padding(
+                            end = MoSoSpacing.md,
+                            start = MoSoSpacing.md,
+                        ),
                     query = "",
                     onQueryChange = {},
                     onSearch = {},


### PR DESCRIPTION
- Making it so if you tap the search tab icon while it's already selected, you will be sent to the search screen
- Increasing the height of the search bar.  The touch target was too small
- Fixing an issue with search bar alignment between the discover screen and the search screen