### PR TITLE
Performance issues

### DIFF
--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/tabs/MoSoScrollableTabRow.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/tabs/MoSoScrollableTabRow.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -39,8 +38,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -48,6 +49,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
@@ -112,7 +114,14 @@ fun MoSoTabRow(
             )
         }
 
-        BoxWithConstraints {
+        var maxWidth by remember { mutableIntStateOf(0) }
+
+        Box(
+            modifier = Modifier
+                .onSizeChanged {
+                    maxWidth = it.width
+                }
+        ) {
             SubcomposeLayout(
                 Modifier
                     .fillMaxWidth()
@@ -126,7 +135,7 @@ fun MoSoTabRow(
                 val calculatedTabMinWidth = calculateTabMinWidth(
                     tabWidthValuesPx = tabMeasurables
                         .map { it.maxIntrinsicWidth(Constraints.Infinity) },
-                    containerWidthPx = maxWidth.roundToPx()
+                    containerWidthPx = maxWidth
                 )
 
                 val isScrollEnabled = calculatedTabMinWidth == null
@@ -189,7 +198,7 @@ fun MoSoTabRow(
                             val fadeStart = min(FadeWidth.roundToPx(), scrollRemaining)
                             val placeable = it.measure(Constraints.fixed(fadeStart, layoutHeight))
                             placeable.placeRelative(
-                                maxWidth.roundToPx() + scrollState.value - fadeStart,
+                                maxWidth + scrollState.value - fadeStart,
                                 0,
                             )
                         }

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/tabs/MoSoScrollableTabRow.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/tabs/MoSoScrollableTabRow.kt
@@ -114,19 +114,17 @@ fun MoSoTabRow(
             )
         }
 
-        var maxWidth by remember {
-            mutableIntStateOf(0)
-        }
-
-        // trigger recomposition here because values used in SubcomposeLayout do not
-        maxWidth.dp
+        var maxWidth by remember { mutableIntStateOf(0) }
 
         Box(
             modifier = Modifier
+                .fillMaxWidth()
                 .onSizeChanged {
                     maxWidth = it.width
                 }
         ) {
+            // don't compose until we have the max width
+            if (maxWidth == 0) return@Box
             SubcomposeLayout(
                 Modifier
                     .fillMaxWidth()

--- a/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/tabs/MoSoScrollableTabRow.kt
+++ b/core/ui/common/src/main/java/org/mozilla/social/core/ui/common/tabs/MoSoScrollableTabRow.kt
@@ -114,7 +114,12 @@ fun MoSoTabRow(
             )
         }
 
-        var maxWidth by remember { mutableIntStateOf(0) }
+        var maxWidth by remember {
+            mutableIntStateOf(0)
+        }
+
+        // trigger recomposition here because values used in SubcomposeLayout do not
+        maxWidth.dp
 
         Box(
             modifier = Modifier


### PR DESCRIPTION
- Fixing tab row getting recomposed way too often
  - I guess `BoxWithConstraints` should not be used to get the composable size