### PR TITLE
Bug 1879155 - Add Glean probe-scraper GitHub workflow

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,0 +1,6 @@
+---
+name: Glean probe-scraper
+on: [push, pull_request]
+jobs:
+  glean-probe-scraper:
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
This is needed for new metrics to be published.

Requires https://github.com/mozilla/probe-scraper/pull/685 to land first.