### PR TITLE
Fixing bug with aspect ratio

### DIFF
--- a/core/ui/common/src/main/kotlin/social/firefly/core/ui/common/media/MediaDisplay.kt
+++ b/core/ui/common/src/main/kotlin/social/firefly/core/ui/common/media/MediaDisplay.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,7 +20,9 @@ import androidx.core.net.toUri
 import coil.compose.AsyncImage
 import social.firefly.core.designsystem.theme.FfRadius
 import social.firefly.core.model.Attachment
+import social.firefly.core.ui.common.utils.getMaxWidth
 import social.firefly.core.ui.common.utils.media
+import kotlin.math.roundToInt
 
 @Suppress("MagicNumber")
 @Composable
@@ -79,9 +83,13 @@ private fun SingleAttachment(
             val aspectRatio by remember {
                 mutableFloatStateOf(attachment.meta?.calculateAspectRatio() ?: 1f)
             }
+            // For some reason, just using fillMaxWidth causes issues on some posts
+            // in conjunction with aspect ratio.  It has something to do with using
+            // .height(IntrinsicSize.Min) in PostCard.kt
+            val width = getMaxWidth()
             Attachment(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .width(width)
                     .aspectRatio(aspectRatio),
                 attachment = attachment,
                 onAttachmentClicked = onAttachmentClicked,
@@ -92,10 +100,16 @@ private fun SingleAttachment(
             val aspectRatio by remember {
                 mutableFloatStateOf(attachment.meta?.calculateAspectRatio() ?: 1f)
             }
+            // For some reason, just using fillMaxWidth causes issues on some posts
+            // in conjunction with aspect ratio.  It has something to do with using
+            // .height(IntrinsicSize.Min) in PostCard.kt
+            val width = getMaxWidth()
             attachment.url?.toUri()?.let {
                 VideoPlayer(
+                    modifier = Modifier
+                        .width(width)
+                        .aspectRatio(aspectRatio),
                     uri = it,
-                    aspectRatio = aspectRatio,
                     onVideoClicked = { onAttachmentClicked(attachment) },
                 )
             }
@@ -105,10 +119,16 @@ private fun SingleAttachment(
             val aspectRatio by remember {
                 mutableFloatStateOf(attachment.meta?.calculateAspectRatio() ?: 1f)
             }
+            // For some reason, just using fillMaxWidth causes issues on some posts
+            // in conjunction with aspect ratio.  It has something to do with using
+            // .height(IntrinsicSize.Min) in PostCard.kt
+            val width = getMaxWidth()
             attachment.url?.toUri()?.let {
                 VideoPlayer(
+                    modifier = Modifier
+                        .width(width)
+                        .aspectRatio(aspectRatio),
                     uri = it,
-                    aspectRatio = aspectRatio,
                     onVideoClicked = { onAttachmentClicked(attachment) },
                 )
             }

--- a/core/ui/common/src/main/kotlin/social/firefly/core/ui/common/media/MediaDisplay.kt
+++ b/core/ui/common/src/main/kotlin/social/firefly/core/ui/common/media/MediaDisplay.kt
@@ -76,11 +76,13 @@ private fun SingleAttachment(
 ) {
     when (attachment) {
         is Attachment.Image -> {
+            val aspectRatio by remember {
+                mutableFloatStateOf(attachment.meta?.calculateAspectRatio() ?: 1f)
+            }
             Attachment(
-                modifier =
-                Modifier
+                modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(attachment.meta?.calculateAspectRatio() ?: 1f),
+                    .aspectRatio(aspectRatio),
                 attachment = attachment,
                 onAttachmentClicked = onAttachmentClicked,
             )

--- a/core/ui/common/src/main/kotlin/social/firefly/core/ui/common/media/VideoPlayer.kt
+++ b/core/ui/common/src/main/kotlin/social/firefly/core/ui/common/media/VideoPlayer.kt
@@ -39,14 +39,12 @@ private const val TAG = "VideoPlayer"
 @Composable
 fun VideoPlayer(
     uri: Uri,
+    modifier: Modifier = Modifier,
     loadState: LoadState = LoadState.LOADED,
-    aspectRatio: Float = 1f,
     onVideoClicked: (() -> Unit)? = null,
 ) {
     Box(
-        modifier =
-        Modifier
-            .aspectRatio(aspectRatio)
+        modifier = modifier
             .clip(RoundedCornerShape(FfRadius.media))
             .clickable(
                 enabled = onVideoClicked != null,

--- a/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/PostCard.kt
+++ b/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/PostCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -25,9 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.datetime.Instant
 import social.firefly.common.utils.StringFactory
-import social.firefly.common.utils.timeSinceNow
 import social.firefly.core.designsystem.icon.FfIcons
 import social.firefly.core.designsystem.theme.FfTheme
 import social.firefly.core.designsystem.utils.NoRipple
@@ -56,6 +55,8 @@ fun PostCard(
             ) {
                 if (post.depthLinesUiState != null) {
                     DepthLines(
+                        modifier = Modifier
+                            .fillMaxHeight(),
                         depthLinesUiState = post.depthLinesUiState,
                     )
                 } else {

--- a/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/components/BottomRow.kt
+++ b/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/components/BottomRow.kt
@@ -54,7 +54,6 @@ internal fun BottomRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(40.dp)
     ) {
         Row(
             modifier = Modifier.weight(1f),

--- a/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/components/BottomRow.kt
+++ b/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/components/BottomRow.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -51,7 +52,9 @@ internal fun BottomRow(
     }
 
     Row(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier
+            .fillMaxWidth()
+            .height(40.dp)
     ) {
         Row(
             modifier = Modifier.weight(1f),

--- a/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/components/DepthLines.kt
+++ b/core/ui/postcard/src/main/kotlin/social/firefly/core/ui/postcard/components/DepthLines.kt
@@ -24,6 +24,7 @@ import social.firefly.core.ui.postcard.ExpandRepliesButtonUiState
 @Composable
 fun DepthLines(
     depthLinesUiState: DepthLinesUiState,
+    modifier: Modifier = Modifier,
 ) {
     val spacingWidth = 12
 
@@ -39,8 +40,7 @@ fun DepthLines(
     }
 
     Canvas(
-        modifier = Modifier
-            .fillMaxHeight()
+        modifier = modifier
             .width(width.dp),
     ) {
         val height = size.height


### PR DESCRIPTION
The intrinsic height in PostCard plus the aspect ratio modifier in the MediaDisplay seem to cause an issue where the media will expand outside it's bounds.  Using getMaxWidth seems to fix it.